### PR TITLE
Feature/#13 공통 예외 계층 및 ErrorCode 정의

### DIFF
--- a/src/main/java/com/realteeth/assignment/exception/BaseException.java
+++ b/src/main/java/com/realteeth/assignment/exception/BaseException.java
@@ -1,0 +1,14 @@
+package com.realteeth.assignment.exception;
+
+import lombok.Getter;
+
+@Getter
+public abstract class BaseException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    protected BaseException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/realteeth/assignment/exception/BaseException.java
+++ b/src/main/java/com/realteeth/assignment/exception/BaseException.java
@@ -2,13 +2,20 @@ package com.realteeth.assignment.exception;
 
 import lombok.Getter;
 
+import java.util.Objects;
+
 @Getter
 public abstract class BaseException extends RuntimeException {
 
     private final ErrorCode errorCode;
 
     protected BaseException(ErrorCode errorCode) {
-        super(errorCode.getMessage());
+        super(Objects.requireNonNull(errorCode, "errorCode must not be null").getMessage());
+        this.errorCode = errorCode;
+    }
+
+    protected BaseException(ErrorCode errorCode, Throwable cause) {
+        super(Objects.requireNonNull(errorCode, "errorCode must not be null").getMessage(), cause);
         this.errorCode = errorCode;
     }
 }

--- a/src/main/java/com/realteeth/assignment/exception/ErrorCode.java
+++ b/src/main/java/com/realteeth/assignment/exception/ErrorCode.java
@@ -1,0 +1,25 @@
+package com.realteeth.assignment.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // Job
+    JOB_NOT_FOUND(HttpStatus.NOT_FOUND, "잡을 찾을 수 없습니다."),
+    INVALID_JOB_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    INVALID_STATE_TRANSITION(HttpStatus.CONFLICT, "허용되지 않는 상태 전이입니다."),
+
+    // MockWorker
+    MOCK_WORKER_ERROR(HttpStatus.BAD_GATEWAY, "외부 처리 서비스 오류가 발생했습니다."),
+
+    // Common
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다.");
+
+    private final HttpStatusCode status;
+    private final String message;
+}

--- a/src/main/java/com/realteeth/assignment/exception/ErrorResponse.java
+++ b/src/main/java/com/realteeth/assignment/exception/ErrorResponse.java
@@ -1,0 +1,8 @@
+package com.realteeth.assignment.exception;
+
+public record ErrorResponse(String code, String message) {
+
+    public static ErrorResponse of(ErrorCode errorCode) {
+        return new ErrorResponse(errorCode.name(), errorCode.getMessage());
+    }
+}

--- a/src/main/java/com/realteeth/assignment/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/realteeth/assignment/exception/GlobalExceptionHandler.java
@@ -1,9 +1,11 @@
 package com.realteeth.assignment.exception;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -16,7 +18,8 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> handleException() {
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error("Unhandled exception", e);
         ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
         return ResponseEntity
                 .status(errorCode.getStatus())

--- a/src/main/java/com/realteeth/assignment/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/realteeth/assignment/exception/GlobalExceptionHandler.java
@@ -12,6 +12,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(BaseException.class)
     public ResponseEntity<ErrorResponse> handleBaseException(BaseException e) {
         ErrorCode errorCode = e.getErrorCode();
+        if (errorCode.getStatus().is5xxServerError()) {
+            log.error("Server error: {}", errorCode.getMessage(), e);
+        } else {
+            log.warn("Client error: {}", errorCode.getMessage());
+        }
         return ResponseEntity
                 .status(errorCode.getStatus())
                 .body(ErrorResponse.of(errorCode));

--- a/src/main/java/com/realteeth/assignment/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/realteeth/assignment/exception/GlobalExceptionHandler.java
@@ -1,0 +1,25 @@
+package com.realteeth.assignment.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BaseException.class)
+    public ResponseEntity<ErrorResponse> handleBaseException(BaseException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ErrorResponse.of(errorCode));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException() {
+        ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ErrorResponse.of(errorCode));
+    }
+}

--- a/src/main/java/com/realteeth/assignment/exception/JobException.java
+++ b/src/main/java/com/realteeth/assignment/exception/JobException.java
@@ -1,0 +1,8 @@
+package com.realteeth.assignment.exception;
+
+public class JobException extends BaseException {
+
+    public JobException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/realteeth/assignment/exception/JobException.java
+++ b/src/main/java/com/realteeth/assignment/exception/JobException.java
@@ -5,4 +5,8 @@ public class JobException extends BaseException {
     public JobException(ErrorCode errorCode) {
         super(errorCode);
     }
+
+    public JobException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode, cause);
+    }
 }

--- a/src/main/java/com/realteeth/assignment/exception/MockWorkerException.java
+++ b/src/main/java/com/realteeth/assignment/exception/MockWorkerException.java
@@ -5,4 +5,8 @@ public class MockWorkerException extends BaseException {
     public MockWorkerException(ErrorCode errorCode) {
         super(errorCode);
     }
+
+    public MockWorkerException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode, cause);
+    }
 }

--- a/src/main/java/com/realteeth/assignment/exception/MockWorkerException.java
+++ b/src/main/java/com/realteeth/assignment/exception/MockWorkerException.java
@@ -1,0 +1,8 @@
+package com.realteeth.assignment.exception;
+
+public class MockWorkerException extends BaseException {
+
+    public MockWorkerException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}


### PR DESCRIPTION
## 관련 이슈
closes #13

## 작업 내용
  ErrorCode

  - `HttpStatusCode` 인터페이스 타입 필드로 선언 (비표준 상태 코드 수용 가능성)
  - 도메인별 주석으로 구분 (Job / MockWorker / Common)

  BaseException

  - `RuntimeException` 상속, `ErrorCode` 보유
  - 구체 예외 클래스들이 `super(ErrorCode.XXX)` 호출

  구체 예외 클래스

  - `JobException` — Job 도메인 예외 (JOB_NOT_FOUND, INVALID_JOB_REQUEST, INVALID_STATE_TRANSITION)
  - `MockWorkerException` — 외부 서비스 연동 예외 (MOCK_WORKER_ERROR)
  - 도메인 단위로 묶어 타입 자체가 발생 계층을 전달하도록 설계

  GlobalExceptionHandler

  - `BaseException` 단일 핸들러로 처리, 그 외 → INTERNAL_SERVER_ERROR
  - 응답 body는 `ErrorResponse` record 사용 (`code`, `message`)