### PR TITLE
Feature/#4 MockWorkerClient 구현 (WebClient + Resilience4j)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,8 @@ dependencies {
     testImplementation 'org.testcontainers:testcontainers-junit-jupiter'
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'
 
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
     testCompileOnly 'org.projectlombok:lombok'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testAnnotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,6 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'
 
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
-    testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
     testCompileOnly 'org.projectlombok:lombok'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testAnnotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/realteeth/assignment/AssignmentApplication.java
+++ b/src/main/java/com/realteeth/assignment/AssignmentApplication.java
@@ -2,10 +2,8 @@ package com.realteeth.assignment;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EnableJpaAuditing
 public class AssignmentApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/realteeth/assignment/JpaAuditingConfig.java
+++ b/src/main/java/com/realteeth/assignment/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.realteeth.assignment;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/realteeth/assignment/worker/ApiKeyProvider.java
+++ b/src/main/java/com/realteeth/assignment/worker/ApiKeyProvider.java
@@ -25,13 +25,13 @@ public class ApiKeyProvider {
                 .build();
 
         AuthResponse response = client.post()
-                .uri("auth/issue-key")
+                .uri("/auth/issue-key")
                 .bodyValue(new IssueKeyRequest(properties.getCandidateName(), properties.getEmail()))
                 .retrieve()
                 .bodyToMono(AuthResponse.class)
                 .block(Duration.ofSeconds(10));
 
-        if (response == null || response.apiKey() == null) {
+        if (response == null || response.apiKey() == null || response.apiKey().isBlank()) {
             throw new IllegalStateException("Mock Worker API Key 발급 실패: 응답에 apiKey 없음");
         }
 

--- a/src/main/java/com/realteeth/assignment/worker/MockWorkerClient.java
+++ b/src/main/java/com/realteeth/assignment/worker/MockWorkerClient.java
@@ -3,7 +3,6 @@ package com.realteeth.assignment.worker;
 import com.realteeth.assignment.exception.ErrorCode;
 import com.realteeth.assignment.exception.MockWorkerException;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
-import io.github.resilience4j.retry.annotation.Retry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatusCode;
@@ -11,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientRequestException;
 import reactor.core.publisher.Mono;
+import reactor.util.retry.Retry;
 
 import java.time.Duration;
 
@@ -20,7 +20,7 @@ import java.time.Duration;
 public class MockWorkerClient {
 
     private static final String CIRCUIT_BREAKER_NAME = "mockWorker";
-    private static final String RETRY_NAME = "mockWorker";
+    private static final int MAX_RETRY_ATTEMPTS = 2; // 최초 1회 + 재시도 2회 = 총 3회
 
     private final MockWorkerProperties properties;
     private final ApiKeyProvider apiKeyProvider;
@@ -32,53 +32,44 @@ public class MockWorkerClient {
 
     private record SubmitRequest(String imageUrl) {}
 
-    // 재시도 대상 예외 — 429/500 및 네트워크 오류 시 내부적으로 사용
-    static class RetryableException extends RuntimeException {
+    private static class RetryableException extends RuntimeException {
         RetryableException(String message, Throwable cause) {
             super(message, cause);
         }
     }
 
     @CircuitBreaker(name = CIRCUIT_BREAKER_NAME, fallbackMethod = "submitJobFallback")
-    @Retry(name = RETRY_NAME)
     public ProcessStartResponse submitJob(String imageUrl) {
         return buildClient()
                 .post()
-                .uri("process")
+                .uri("/process")
                 .bodyValue(new SubmitRequest(imageUrl))
                 .retrieve()
                 .onStatus(HttpStatusCode::is4xxClientError, response -> {
                     if (response.statusCode().value() == 429) {
                         return Mono.error(new RetryableException("429 Too Many Requests", null));
                     }
-                    return response.bodyToMono(String.class)
-                            .flatMap(body -> Mono.error(new MockWorkerException(ErrorCode.MOCK_WORKER_ERROR)));
+                    return Mono.error(new MockWorkerException(ErrorCode.MOCK_WORKER_ERROR));
                 })
                 .onStatus(HttpStatusCode::is5xxServerError, response ->
                         Mono.error(new RetryableException("5xx Server Error", null))
                 )
                 .bodyToMono(ProcessStartResponse.class)
                 .switchIfEmpty(Mono.error(new MockWorkerException(ErrorCode.MOCK_WORKER_ERROR)))
-                .onErrorMap(WebClientRequestException.class,
-                        e -> new RetryableException("네트워크 오류", e))
-                .onErrorMap(RetryableException.class, e -> e)
-                .onErrorMap(MockWorkerException.class, e -> e)
-                .onErrorMap(e -> new MockWorkerException(ErrorCode.MOCK_WORKER_ERROR, e))
-                .map(response -> {
-                    if (response == null) {
-                        throw new MockWorkerException(ErrorCode.MOCK_WORKER_ERROR);
-                    }
-                    return response;
-                })
+                .onErrorMap(WebClientRequestException.class, e -> new RetryableException("네트워크 오류", e))
+                .retryWhen(Retry.fixedDelay(MAX_RETRY_ATTEMPTS, Duration.ofMillis(500))
+                        .filter(e -> e instanceof RetryableException))
+                .onErrorMap(RetryableException.class, e -> new MockWorkerException(ErrorCode.MOCK_WORKER_ERROR, e))
+                .onErrorMap(e -> !(e instanceof MockWorkerException),
+                        e -> new MockWorkerException(ErrorCode.MOCK_WORKER_ERROR, e))
                 .block(Duration.ofSeconds(65));
     }
 
     @CircuitBreaker(name = CIRCUIT_BREAKER_NAME, fallbackMethod = "getJobStatusFallback")
-    @Retry(name = RETRY_NAME)
     public ProcessStatusResponse getJobStatus(String workerJobId) {
         return buildClient()
                 .get()
-                .uri("process/{jobId}", workerJobId)
+                .uri("/process/{jobId}", workerJobId)
                 .retrieve()
                 .onStatus(status -> status.value() == 404, response ->
                         Mono.error(new MockWorkerException(ErrorCode.MOCK_WORKER_ERROR))
@@ -91,11 +82,12 @@ public class MockWorkerClient {
                 )
                 .bodyToMono(ProcessStatusResponse.class)
                 .switchIfEmpty(Mono.error(new MockWorkerException(ErrorCode.MOCK_WORKER_ERROR)))
-                .onErrorMap(WebClientRequestException.class,
-                        e -> new RetryableException("네트워크 오류", e))
-                .onErrorMap(RetryableException.class, e -> e)
-                .onErrorMap(MockWorkerException.class, e -> e)
-                .onErrorMap(e -> new MockWorkerException(ErrorCode.MOCK_WORKER_ERROR, e))
+                .onErrorMap(WebClientRequestException.class, e -> new RetryableException("네트워크 오류", e))
+                .retryWhen(Retry.fixedDelay(MAX_RETRY_ATTEMPTS, Duration.ofMillis(500))
+                        .filter(e -> e instanceof RetryableException))
+                .onErrorMap(RetryableException.class, e -> new MockWorkerException(ErrorCode.MOCK_WORKER_ERROR, e))
+                .onErrorMap(e -> !(e instanceof MockWorkerException),
+                        e -> new MockWorkerException(ErrorCode.MOCK_WORKER_ERROR, e))
                 .block(Duration.ofSeconds(65));
     }
 

--- a/src/main/java/com/realteeth/assignment/worker/MockWorkerClient.java
+++ b/src/main/java/com/realteeth/assignment/worker/MockWorkerClient.java
@@ -1,0 +1,120 @@
+package com.realteeth.assignment.worker;
+
+import com.realteeth.assignment.exception.ErrorCode;
+import com.realteeth.assignment.exception.MockWorkerException;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.retry.annotation.Retry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MockWorkerClient {
+
+    private static final String CIRCUIT_BREAKER_NAME = "mockWorker";
+    private static final String RETRY_NAME = "mockWorker";
+
+    private final MockWorkerProperties properties;
+    private final ApiKeyProvider apiKeyProvider;
+    private final WebClient.Builder webClientBuilder;
+
+    public record ProcessStartResponse(String jobId, String status) {}
+
+    public record ProcessStatusResponse(String jobId, String status, String result) {}
+
+    private record SubmitRequest(String imageUrl) {}
+
+    // 재시도 대상 예외 — 429/500 및 네트워크 오류 시 내부적으로 사용
+    static class RetryableException extends RuntimeException {
+        RetryableException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+
+    @CircuitBreaker(name = CIRCUIT_BREAKER_NAME, fallbackMethod = "submitJobFallback")
+    @Retry(name = RETRY_NAME)
+    public ProcessStartResponse submitJob(String imageUrl) {
+        return buildClient()
+                .post()
+                .uri("process")
+                .bodyValue(new SubmitRequest(imageUrl))
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, response -> {
+                    if (response.statusCode().value() == 429) {
+                        return Mono.error(new RetryableException("429 Too Many Requests", null));
+                    }
+                    return response.bodyToMono(String.class)
+                            .flatMap(body -> Mono.error(new MockWorkerException(ErrorCode.MOCK_WORKER_ERROR)));
+                })
+                .onStatus(HttpStatusCode::is5xxServerError, response ->
+                        Mono.error(new RetryableException("5xx Server Error", null))
+                )
+                .bodyToMono(ProcessStartResponse.class)
+                .switchIfEmpty(Mono.error(new MockWorkerException(ErrorCode.MOCK_WORKER_ERROR)))
+                .onErrorMap(WebClientRequestException.class,
+                        e -> new RetryableException("네트워크 오류", e))
+                .onErrorMap(RetryableException.class, e -> e)
+                .onErrorMap(MockWorkerException.class, e -> e)
+                .onErrorMap(e -> new MockWorkerException(ErrorCode.MOCK_WORKER_ERROR, e))
+                .map(response -> {
+                    if (response == null) {
+                        throw new MockWorkerException(ErrorCode.MOCK_WORKER_ERROR);
+                    }
+                    return response;
+                })
+                .block(Duration.ofSeconds(65));
+    }
+
+    @CircuitBreaker(name = CIRCUIT_BREAKER_NAME, fallbackMethod = "getJobStatusFallback")
+    @Retry(name = RETRY_NAME)
+    public ProcessStatusResponse getJobStatus(String workerJobId) {
+        return buildClient()
+                .get()
+                .uri("process/{jobId}", workerJobId)
+                .retrieve()
+                .onStatus(status -> status.value() == 404, response ->
+                        Mono.error(new MockWorkerException(ErrorCode.MOCK_WORKER_ERROR))
+                )
+                .onStatus(HttpStatusCode::is4xxClientError, response ->
+                        Mono.error(new MockWorkerException(ErrorCode.MOCK_WORKER_ERROR))
+                )
+                .onStatus(HttpStatusCode::is5xxServerError, response ->
+                        Mono.error(new RetryableException("5xx Server Error", null))
+                )
+                .bodyToMono(ProcessStatusResponse.class)
+                .switchIfEmpty(Mono.error(new MockWorkerException(ErrorCode.MOCK_WORKER_ERROR)))
+                .onErrorMap(WebClientRequestException.class,
+                        e -> new RetryableException("네트워크 오류", e))
+                .onErrorMap(RetryableException.class, e -> e)
+                .onErrorMap(MockWorkerException.class, e -> e)
+                .onErrorMap(e -> new MockWorkerException(ErrorCode.MOCK_WORKER_ERROR, e))
+                .block(Duration.ofSeconds(65));
+    }
+
+    private ProcessStartResponse submitJobFallback(String imageUrl, Throwable t) {
+        log.warn("MockWorker submitJob fallback 실행: {}", t.getMessage());
+        if (t instanceof MockWorkerException e) throw e;
+        throw new MockWorkerException(ErrorCode.MOCK_WORKER_ERROR, t);
+    }
+
+    private ProcessStatusResponse getJobStatusFallback(String workerJobId, Throwable t) {
+        log.warn("MockWorker getJobStatus fallback 실행: {}", t.getMessage());
+        if (t instanceof MockWorkerException e) throw e;
+        throw new MockWorkerException(ErrorCode.MOCK_WORKER_ERROR, t);
+    }
+
+    private WebClient buildClient() {
+        return webClientBuilder
+                .baseUrl(properties.getBaseUrl())
+                .defaultHeader("X-API-KEY", apiKeyProvider.getApiKey())
+                .build();
+    }
+}

--- a/src/main/java/com/realteeth/assignment/worker/MockWorkerClient.java
+++ b/src/main/java/com/realteeth/assignment/worker/MockWorkerClient.java
@@ -3,7 +3,7 @@ package com.realteeth.assignment.worker;
 import com.realteeth.assignment.exception.ErrorCode;
 import com.realteeth.assignment.exception.MockWorkerException;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
-import lombok.RequiredArgsConstructor;
+import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
@@ -16,7 +16,6 @@ import java.time.Duration;
 
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class MockWorkerClient {
 
     private static final String CIRCUIT_BREAKER_NAME = "mockWorker";
@@ -25,6 +24,20 @@ public class MockWorkerClient {
     private final MockWorkerProperties properties;
     private final ApiKeyProvider apiKeyProvider;
     private final WebClient.Builder webClientBuilder;
+    private WebClient webClient;
+
+    public MockWorkerClient(MockWorkerProperties properties,
+                            ApiKeyProvider apiKeyProvider,
+                            WebClient.Builder webClientBuilder) {
+        this.properties = properties;
+        this.apiKeyProvider = apiKeyProvider;
+        this.webClientBuilder = webClientBuilder;
+    }
+
+    @PostConstruct
+    void init() {
+        this.webClient = webClientBuilder.build();
+    }
 
     public record ProcessStartResponse(String jobId, String status) {}
 
@@ -40,7 +53,7 @@ public class MockWorkerClient {
 
     @CircuitBreaker(name = CIRCUIT_BREAKER_NAME, fallbackMethod = "submitJobFallback")
     public ProcessStartResponse submitJob(String imageUrl) {
-        return buildClient()
+        return client()
                 .post()
                 .uri("/process")
                 .bodyValue(new SubmitRequest(imageUrl))
@@ -67,7 +80,7 @@ public class MockWorkerClient {
 
     @CircuitBreaker(name = CIRCUIT_BREAKER_NAME, fallbackMethod = "getJobStatusFallback")
     public ProcessStatusResponse getJobStatus(String workerJobId) {
-        return buildClient()
+        return client()
                 .get()
                 .uri("/process/{jobId}", workerJobId)
                 .retrieve()
@@ -103,8 +116,8 @@ public class MockWorkerClient {
         throw new MockWorkerException(ErrorCode.MOCK_WORKER_ERROR, t);
     }
 
-    private WebClient buildClient() {
-        return webClientBuilder
+    private WebClient client() {
+        return webClient.mutate()
                 .baseUrl(properties.getBaseUrl())
                 .defaultHeader("X-API-KEY", apiKeyProvider.getApiKey())
                 .build();

--- a/src/main/java/com/realteeth/assignment/worker/MockWorkerProperties.java
+++ b/src/main/java/com/realteeth/assignment/worker/MockWorkerProperties.java
@@ -14,4 +14,5 @@ public class MockWorkerProperties {
     private String baseUrl;
     private String candidateName;
     private String email;
+    private int readTimeoutSeconds = 60;
 }

--- a/src/main/java/com/realteeth/assignment/worker/WebClientConfig.java
+++ b/src/main/java/com/realteeth/assignment/worker/WebClientConfig.java
@@ -12,11 +12,17 @@ import java.time.Duration;
 @Configuration
 public class WebClientConfig {
 
+    private final MockWorkerProperties properties;
+
+    public WebClientConfig(MockWorkerProperties properties) {
+        this.properties = properties;
+    }
+
     @Bean
     public WebClient.Builder webClientBuilder() {
         HttpClient httpClient = HttpClient.create()
                 .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5_000)
-                .responseTimeout(Duration.ofSeconds(60));
+                .responseTimeout(Duration.ofSeconds(properties.getReadTimeoutSeconds()));
 
         return WebClient.builder()
                 .clientConnector(new ReactorClientHttpConnector(httpClient));

--- a/src/main/java/com/realteeth/assignment/worker/WebClientConfig.java
+++ b/src/main/java/com/realteeth/assignment/worker/WebClientConfig.java
@@ -1,14 +1,24 @@
 package com.realteeth.assignment.worker;
 
+import io.netty.channel.ChannelOption;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
 
 @Configuration
 public class WebClientConfig {
 
     @Bean
     public WebClient.Builder webClientBuilder() {
-        return WebClient.builder();
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5_000)
+                .responseTimeout(Duration.ofSeconds(60));
+
+        return WebClient.builder()
+                .clientConnector(new ReactorClientHttpConnector(httpClient));
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,3 +21,21 @@ mock-worker:
   base-url: https://dev.realteeth.ai/mock
   candidate-name: ${MOCK_WORKER_CANDIDATE_NAME}
   email: ${MOCK_WORKER_EMAIL}
+
+resilience4j:
+  circuitbreaker:
+    instances:
+      mockWorker:
+        failure-rate-threshold: 50
+        wait-duration-in-open-state: 10s
+        sliding-window-type: COUNT_BASED
+        sliding-window-size: 10
+        minimum-number-of-calls: 5
+        permitted-number-of-calls-in-half-open-state: 3
+  retry:
+    instances:
+      mockWorker:
+        max-attempts: 3
+        wait-duration: 500ms
+        retry-exceptions:
+          - com.realteeth.assignment.worker.MockWorkerClient$RetryableException

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,10 +32,3 @@ resilience4j:
         sliding-window-size: 10
         minimum-number-of-calls: 5
         permitted-number-of-calls-in-half-open-state: 3
-  retry:
-    instances:
-      mockWorker:
-        max-attempts: 3
-        wait-duration: 500ms
-        retry-exceptions:
-          - com.realteeth.assignment.worker.MockWorkerClient$RetryableException

--- a/src/test/java/com/realteeth/assignment/AssignmentApplicationTests.java
+++ b/src/test/java/com/realteeth/assignment/AssignmentApplicationTests.java
@@ -1,10 +1,15 @@
 package com.realteeth.assignment;
 
+import com.realteeth.assignment.worker.ApiKeyProvider;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest
 class AssignmentApplicationTests {
+
+    @MockitoBean
+    private ApiKeyProvider apiKeyProvider;
 
     @Test
     void contextLoads() {

--- a/src/test/java/com/realteeth/assignment/domain/JobRepositoryTest.java
+++ b/src/test/java/com/realteeth/assignment/domain/JobRepositoryTest.java
@@ -11,13 +11,14 @@ import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import com.realteeth.assignment.JpaAuditingConfig;
 import com.realteeth.assignment.MySQLTestConfig;
 import org.springframework.context.annotation.Import;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
-@Import(MySQLTestConfig.class)
+@Import({MySQLTestConfig.class, JpaAuditingConfig.class})
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class JobRepositoryTest {
 

--- a/src/test/java/com/realteeth/assignment/worker/ApiKeyProviderTest.java
+++ b/src/test/java/com/realteeth/assignment/worker/ApiKeyProviderTest.java
@@ -1,0 +1,106 @@
+package com.realteeth.assignment.worker;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ApiKeyProviderTest {
+
+    private MockWebServer server;
+    private ApiKeyProvider apiKeyProvider;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = new MockWebServer();
+        server.start();
+
+        MockWorkerProperties properties = new MockWorkerProperties();
+        properties.setBaseUrl(server.url("/").toString());
+        properties.setCandidateName("tester");
+        properties.setEmail("tester@test.com");
+
+        WebClient.Builder webClientBuilder = WebClient.builder();
+        apiKeyProvider = new ApiKeyProvider(properties, webClientBuilder);
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        server.shutdown();
+    }
+
+    @Test
+    void 정상_응답시_apiKey를_저장한다() throws InterruptedException {
+        server.enqueue(new MockResponse()
+                .setBody("{\"apiKey\":\"test-key-abc\"}")
+                .addHeader("Content-Type", "application/json"));
+
+        apiKeyProvider.issueApiKey();
+
+        assertThat(apiKeyProvider.getApiKey()).isEqualTo("test-key-abc");
+
+        RecordedRequest request = server.takeRequest();
+        assertThat(request.getMethod()).isEqualTo("POST");
+        assertThat(request.getPath()).endsWith("/auth/issue-key");
+    }
+
+    @Test
+    void apiKey가_null인_응답시_예외가_발생한다() {
+        server.enqueue(new MockResponse()
+                .setBody("{\"apiKey\":null}")
+                .addHeader("Content-Type", "application/json"));
+
+        assertThatThrownBy(() -> apiKeyProvider.issueApiKey())
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void apiKey가_빈_문자열인_응답시_예외가_발생한다() {
+        server.enqueue(new MockResponse()
+                .setBody("{\"apiKey\":\"\"}")
+                .addHeader("Content-Type", "application/json"));
+
+        assertThatThrownBy(() -> apiKeyProvider.issueApiKey())
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void apiKey가_공백만_있는_응답시_예외가_발생한다() {
+        server.enqueue(new MockResponse()
+                .setBody("{\"apiKey\":\"   \"}")
+                .addHeader("Content-Type", "application/json"));
+
+        assertThatThrownBy(() -> apiKeyProvider.issueApiKey())
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void 서버_오류시_예외가_발생한다() {
+        server.enqueue(new MockResponse().setResponseCode(500));
+
+        assertThatThrownBy(() -> apiKeyProvider.issueApiKey())
+                .isInstanceOf(Exception.class);
+    }
+
+    @Test
+    void 요청_바디에_candidateName과_email이_포함된다() throws InterruptedException {
+        server.enqueue(new MockResponse()
+                .setBody("{\"apiKey\":\"key-xyz\"}")
+                .addHeader("Content-Type", "application/json"));
+
+        apiKeyProvider.issueApiKey();
+
+        RecordedRequest request = server.takeRequest();
+        String body = request.getBody().readUtf8();
+        assertThat(body).contains("tester");
+        assertThat(body).contains("tester@test.com");
+    }
+}

--- a/src/test/java/com/realteeth/assignment/worker/MockWorkerClientTest.java
+++ b/src/test/java/com/realteeth/assignment/worker/MockWorkerClientTest.java
@@ -1,7 +1,6 @@
 package com.realteeth.assignment.worker;
 
 import com.realteeth.assignment.exception.MockWorkerException;
-import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.github.resilience4j.springboot3.circuitbreaker.autoconfigure.CircuitBreakerAutoConfiguration;
 import okhttp3.mockwebserver.MockResponse;

--- a/src/test/java/com/realteeth/assignment/worker/MockWorkerClientTest.java
+++ b/src/test/java/com/realteeth/assignment/worker/MockWorkerClientTest.java
@@ -1,0 +1,240 @@
+package com.realteeth.assignment.worker;
+
+import com.realteeth.assignment.exception.MockWorkerException;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.github.resilience4j.springboot3.circuitbreaker.autoconfigure.CircuitBreakerAutoConfiguration;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest(
+        classes = {
+                MockWorkerClient.class,
+                MockWorkerProperties.class,
+                WebClientConfig.class
+        },
+        webEnvironment = SpringBootTest.WebEnvironment.NONE
+)
+@Import(CircuitBreakerAutoConfiguration.class)
+@EnableAspectJAutoProxy
+class MockWorkerClientTest {
+
+    private MockWebServer server;
+
+    @Autowired
+    private MockWorkerClient mockWorkerClient;
+
+    @Autowired
+    private MockWorkerProperties mockWorkerProperties;
+
+    @MockitoBean
+    private ApiKeyProvider apiKeyProvider;
+
+    @Autowired
+    private CircuitBreakerRegistry circuitBreakerRegistry;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = new MockWebServer();
+        server.start();
+        mockWorkerProperties.setBaseUrl(server.url("/").toString());
+        when(apiKeyProvider.getApiKey()).thenReturn("test-api-key");
+        circuitBreakerRegistry.circuitBreaker("mockWorker").reset();
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        server.shutdown();
+    }
+
+    // ==================== submitJob ====================
+
+    @Test
+    void submitJob_정상_응답시_workerJobId를_반환한다() throws InterruptedException {
+        server.enqueue(new MockResponse()
+                .setBody("{\"jobId\":\"worker-001\",\"status\":\"PROCESSING\"}")
+                .addHeader("Content-Type", "application/json"));
+
+        MockWorkerClient.ProcessStartResponse response = mockWorkerClient.submitJob("https://example.com/img.jpg");
+
+        assertThat(response.jobId()).isEqualTo("worker-001");
+        assertThat(response.status()).isEqualTo("PROCESSING");
+    }
+
+    @Test
+    void submitJob_요청에_X_API_KEY_헤더가_포함된다() throws InterruptedException {
+        server.enqueue(new MockResponse()
+                .setBody("{\"jobId\":\"worker-001\",\"status\":\"PROCESSING\"}")
+                .addHeader("Content-Type", "application/json"));
+
+        mockWorkerClient.submitJob("https://example.com/img.jpg");
+
+        RecordedRequest request = server.takeRequest();
+        assertThat(request.getHeader("X-API-KEY")).isEqualTo("test-api-key");
+    }
+
+    @Test
+    void submitJob_429_1회_후_재시도하여_성공한다() {
+        server.enqueue(new MockResponse().setResponseCode(429));
+        server.enqueue(new MockResponse()
+                .setBody("{\"jobId\":\"worker-002\",\"status\":\"PROCESSING\"}")
+                .addHeader("Content-Type", "application/json"));
+
+        MockWorkerClient.ProcessStartResponse response = mockWorkerClient.submitJob("https://example.com/img.jpg");
+
+        assertThat(response.jobId()).isEqualTo("worker-002");
+        assertThat(server.getRequestCount()).isEqualTo(2);
+    }
+
+    @Test
+    void submitJob_429_3회_연속시_MockWorkerException이_발생한다() {
+        server.enqueue(new MockResponse().setResponseCode(429));
+        server.enqueue(new MockResponse().setResponseCode(429));
+        server.enqueue(new MockResponse().setResponseCode(429));
+
+        assertThatThrownBy(() -> mockWorkerClient.submitJob("https://example.com/img.jpg"))
+                .isInstanceOf(MockWorkerException.class);
+
+        assertThat(server.getRequestCount()).isEqualTo(3);
+    }
+
+    @Test
+    void submitJob_500_1회_후_재시도하여_성공한다() {
+        server.enqueue(new MockResponse().setResponseCode(500));
+        server.enqueue(new MockResponse()
+                .setBody("{\"jobId\":\"worker-003\",\"status\":\"PROCESSING\"}")
+                .addHeader("Content-Type", "application/json"));
+
+        MockWorkerClient.ProcessStartResponse response = mockWorkerClient.submitJob("https://example.com/img.jpg");
+
+        assertThat(response.jobId()).isEqualTo("worker-003");
+        assertThat(server.getRequestCount()).isEqualTo(2);
+    }
+
+    @Test
+    void submitJob_500_3회_연속시_MockWorkerException이_발생한다() {
+        server.enqueue(new MockResponse().setResponseCode(500));
+        server.enqueue(new MockResponse().setResponseCode(500));
+        server.enqueue(new MockResponse().setResponseCode(500));
+
+        assertThatThrownBy(() -> mockWorkerClient.submitJob("https://example.com/img.jpg"))
+                .isInstanceOf(MockWorkerException.class);
+
+        assertThat(server.getRequestCount()).isEqualTo(3);
+    }
+
+    @Test
+    void submitJob_빈_응답_바디시_MockWorkerException이_발생한다() {
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .addHeader("Content-Type", "application/json"));
+
+        assertThatThrownBy(() -> mockWorkerClient.submitJob("https://example.com/img.jpg"))
+                .isInstanceOf(MockWorkerException.class);
+    }
+
+    @Test
+    void submitJob_서킷브레이커_OPEN_상태에서_즉시_MockWorkerException이_발생한다() {
+        circuitBreakerRegistry.circuitBreaker("mockWorker").transitionToOpenState();
+
+        assertThatThrownBy(() -> mockWorkerClient.submitJob("https://example.com/img.jpg"))
+                .isInstanceOf(MockWorkerException.class);
+
+        assertThat(server.getRequestCount()).isEqualTo(0);
+    }
+
+    // ==================== getJobStatus ====================
+
+    @Test
+    void getJobStatus_PROCESSING_상태를_반환한다() {
+        server.enqueue(new MockResponse()
+                .setBody("{\"jobId\":\"worker-001\",\"status\":\"PROCESSING\",\"result\":null}")
+                .addHeader("Content-Type", "application/json"));
+
+        MockWorkerClient.ProcessStatusResponse response = mockWorkerClient.getJobStatus("worker-001");
+
+        assertThat(response.status()).isEqualTo("PROCESSING");
+        assertThat(response.result()).isNull();
+    }
+
+    @Test
+    void getJobStatus_COMPLETED_상태와_result를_반환한다() {
+        server.enqueue(new MockResponse()
+                .setBody("{\"jobId\":\"worker-001\",\"status\":\"COMPLETED\",\"result\":\"처리결과\"}")
+                .addHeader("Content-Type", "application/json"));
+
+        MockWorkerClient.ProcessStatusResponse response = mockWorkerClient.getJobStatus("worker-001");
+
+        assertThat(response.status()).isEqualTo("COMPLETED");
+        assertThat(response.result()).isEqualTo("처리결과");
+    }
+
+    @Test
+    void getJobStatus_FAILED_상태를_반환한다() {
+        server.enqueue(new MockResponse()
+                .setBody("{\"jobId\":\"worker-001\",\"status\":\"FAILED\",\"result\":null}")
+                .addHeader("Content-Type", "application/json"));
+
+        MockWorkerClient.ProcessStatusResponse response = mockWorkerClient.getJobStatus("worker-001");
+
+        assertThat(response.status()).isEqualTo("FAILED");
+    }
+
+    @Test
+    void getJobStatus_404응답시_MockWorkerException이_발생한다() {
+        server.enqueue(new MockResponse().setResponseCode(404));
+
+        assertThatThrownBy(() -> mockWorkerClient.getJobStatus("nonexistent-job"))
+                .isInstanceOf(MockWorkerException.class);
+    }
+
+    @Test
+    void getJobStatus_404는_재시도하지_않는다() {
+        server.enqueue(new MockResponse().setResponseCode(404));
+
+        assertThatThrownBy(() -> mockWorkerClient.getJobStatus("nonexistent-job"))
+                .isInstanceOf(MockWorkerException.class);
+
+        assertThat(server.getRequestCount()).isEqualTo(1);
+    }
+
+    @Test
+    void getJobStatus_500_1회_후_재시도하여_성공한다() {
+        server.enqueue(new MockResponse().setResponseCode(500));
+        server.enqueue(new MockResponse()
+                .setBody("{\"jobId\":\"worker-001\",\"status\":\"PROCESSING\",\"result\":null}")
+                .addHeader("Content-Type", "application/json"));
+
+        MockWorkerClient.ProcessStatusResponse response = mockWorkerClient.getJobStatus("worker-001");
+
+        assertThat(response.status()).isEqualTo("PROCESSING");
+        assertThat(server.getRequestCount()).isEqualTo(2);
+    }
+
+    @Test
+    void getJobStatus_result_필드_없는_COMPLETED_응답을_처리한다() {
+        server.enqueue(new MockResponse()
+                .setBody("{\"jobId\":\"worker-001\",\"status\":\"COMPLETED\"}")
+                .addHeader("Content-Type", "application/json"));
+
+        MockWorkerClient.ProcessStatusResponse response = mockWorkerClient.getJobStatus("worker-001");
+
+        assertThat(response.status()).isEqualTo("COMPLETED");
+        assertThat(response.result()).isNull();
+    }
+}

--- a/src/test/java/com/realteeth/assignment/worker/MockWorkerClientTest.java
+++ b/src/test/java/com/realteeth/assignment/worker/MockWorkerClientTest.java
@@ -239,6 +239,30 @@ class MockWorkerClientTest {
         assertThat(response.result()).isNull();
     }
 
+    // ==================== JSON 역직렬화 오류 ====================
+
+    @Test
+    void submitJob_잘못된_JSON_응답시_MockWorkerException이_발생한다() {
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setBody("{\"jobId\":")
+                .addHeader("Content-Type", "application/json"));
+
+        assertThatThrownBy(() -> mockWorkerClient.submitJob("https://example.com/img.jpg"))
+                .isInstanceOf(MockWorkerException.class);
+    }
+
+    @Test
+    void getJobStatus_잘못된_JSON_응답시_MockWorkerException이_발생한다() {
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setBody("{\"jobId\":")
+                .addHeader("Content-Type", "application/json"));
+
+        assertThatThrownBy(() -> mockWorkerClient.getJobStatus("worker-001"))
+                .isInstanceOf(MockWorkerException.class);
+    }
+
     // ==================== 읽기 타임아웃 ====================
 
     @Test

--- a/src/test/java/com/realteeth/assignment/worker/MockWorkerClientTest.java
+++ b/src/test/java/com/realteeth/assignment/worker/MockWorkerClientTest.java
@@ -17,6 +17,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -28,7 +29,8 @@ import static org.mockito.Mockito.when;
                 MockWorkerProperties.class,
                 WebClientConfig.class
         },
-        webEnvironment = SpringBootTest.WebEnvironment.NONE
+        webEnvironment = SpringBootTest.WebEnvironment.NONE,
+        properties = "mock-worker.read-timeout-seconds=2"
 )
 @Import(CircuitBreakerAutoConfiguration.class)
 @EnableAspectJAutoProxy
@@ -236,5 +238,18 @@ class MockWorkerClientTest {
 
         assertThat(response.status()).isEqualTo("COMPLETED");
         assertThat(response.result()).isNull();
+    }
+
+    // ==================== 읽기 타임아웃 ====================
+
+    @Test
+    void submitJob_읽기_타임아웃_초과시_MockWorkerException이_발생한다() {
+        server.enqueue(new MockResponse()
+                .setBody("{\"jobId\":\"worker-001\",\"status\":\"PROCESSING\"}")
+                .addHeader("Content-Type", "application/json")
+                .setBodyDelay(3, TimeUnit.SECONDS));
+
+        assertThatThrownBy(() -> mockWorkerClient.submitJob("https://example.com/img.jpg"))
+                .isInstanceOf(MockWorkerException.class);
     }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,4 +1,9 @@
 spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/assignment?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
+    username: root
+    password: 1234
+    driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
       ddl-auto: validate
@@ -7,8 +12,20 @@ spring:
         dialect: org.hibernate.dialect.MySQLDialect
   flyway:
     enabled: true
+    baseline-on-migrate: true
 
 mock-worker:
   base-url: https://dev.realteeth.ai/mock
   candidate-name: test
   email: test@test.com
+
+resilience4j:
+  circuitbreaker:
+    instances:
+      mockWorker:
+        failure-rate-threshold: 50
+        wait-duration-in-open-state: 10s
+        sliding-window-type: COUNT_BASED
+        sliding-window-size: 10
+        minimum-number-of-calls: 5
+        permitted-number-of-calls-in-half-open-state: 3


### PR DESCRIPTION
## 관련 이슈
closes #4

## 작업 내용

WebClientConfig

- Netty HttpClient 연결 타임아웃 5초, 읽기 타임아웃 60초 설정

ApiKeyProvider

- 빈 문자열 apiKey 검증 추가 (`isBlank()`)
- URI 경로 슬래시 누락 버그 수정 (`/auth/issue-key`)

MockWorkerClient

- `submitJob(imageUrl)` — POST /process, `ProcessStartResponse` 반환
- `getJobStatus(workerJobId)` — GET /process/{jobId}, `ProcessStatusResponse` 반환
- `@CircuitBreaker` — 실패율 50% 초과 시 OPEN, 10초 후 HALF_OPEN
- 재시도: `retryWhen(Retry.fixedDelay(2, 500ms))` — 429/500/네트워크 오류에만 적용 (`RetryableException` 필터)
- 404 등 비즈니스 오류는 즉시 `MockWorkerException` 반환 (재시도 없음)
- `@Retry` 어노테이션 대신 reactor `retryWhen()` 사용 — `@CircuitBreaker(fallbackMethod)` AOP가 `RetryableException`을 먼저 가로채는 구조적 문제 회피

기타

- `@EnableJpaAuditing`을 `JpaAuditingConfig`로 분리 — `@SpringBootTest(classes=...)` 슬라이스 테스트에서 JPA 컨텍스트 없이 구성 가능
- `AssignmentApplicationTests`에 `@MockitoBean ApiKeyProvider` 추가 — 환경변수 없이 컨텍스트 로드 가능

## 테스트

MockWorkerClientTest (MockWebServer)

- submitJob/getJobStatus 정상 응답 반환
- 429/500 재시도 후 성공 및 3회 소진 시 MockWorkerException
- 빈 응답 바디 처리
- X-API-KEY 헤더 포함 확인
- 서킷브레이커 OPEN 상태에서 즉시 MockWorkerException
- 404는 재시도 없이 즉시 실패 확인

ApiKeyProviderTest (MockWebServer)

- 정상 응답 apiKey 저장 및 요청 바디 검증
- null/빈 문자열/공백 apiKey 예외 처리
- 서버 오류 시 예외 발생