### PR TITLE
Feature/#14 Job CRUD API (JobService + 3개 엔드포인트)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ ext {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-flyway'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'

--- a/src/main/java/com/realteeth/assignment/api/controller/JobController.java
+++ b/src/main/java/com/realteeth/assignment/api/controller/JobController.java
@@ -1,0 +1,49 @@
+package com.realteeth.assignment.api.controller;
+
+import com.realteeth.assignment.api.dto.JobResponse;
+import com.realteeth.assignment.api.dto.JobSubmitRequest;
+import com.realteeth.assignment.domain.enums.JobStatus;
+import com.realteeth.assignment.service.JobService;
+import com.realteeth.assignment.service.JobSubmitResult;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/jobs")
+@RequiredArgsConstructor
+public class JobController {
+
+    private final JobService jobService;
+
+    @PostMapping
+    public ResponseEntity<JobResponse> submit(@Valid @RequestBody JobSubmitRequest request) {
+        JobSubmitResult result = jobService.submitJob(request.imageUrl());
+        JobResponse response = JobResponse.from(result.job());
+        if (result.created()) {
+            return ResponseEntity.status(201).body(response);
+        }
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{jobId}")
+    public ResponseEntity<JobResponse> getJob(@PathVariable UUID jobId) {
+        return ResponseEntity.ok(JobResponse.from(jobService.getJob(jobId)));
+    }
+
+    @GetMapping
+    public ResponseEntity<Page<JobResponse>> getJobs(
+            @RequestParam(required = false) JobStatus status,
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        Page<JobResponse> page = jobService.getJobs(status, pageable).map(JobResponse::from);
+        return ResponseEntity.ok(page);
+    }
+}

--- a/src/main/java/com/realteeth/assignment/api/dto/JobResponse.java
+++ b/src/main/java/com/realteeth/assignment/api/dto/JobResponse.java
@@ -1,0 +1,29 @@
+package com.realteeth.assignment.api.dto;
+
+import com.realteeth.assignment.domain.entity.Job;
+import com.realteeth.assignment.domain.enums.JobStatus;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record JobResponse(
+        UUID jobId,
+        JobStatus status,
+        String imageUrl,
+        String result,
+        String errorMessage,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static JobResponse from(Job job) {
+        return new JobResponse(
+                job.getJobId(),
+                job.getStatus(),
+                job.getImageUrl(),
+                job.getResult(),
+                job.getErrorMessage(),
+                job.getCreatedAt(),
+                job.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/realteeth/assignment/api/dto/JobSubmitRequest.java
+++ b/src/main/java/com/realteeth/assignment/api/dto/JobSubmitRequest.java
@@ -1,0 +1,5 @@
+package com.realteeth.assignment.api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record JobSubmitRequest(@NotBlank String imageUrl) {}

--- a/src/main/java/com/realteeth/assignment/domain/repository/JobRepository.java
+++ b/src/main/java/com/realteeth/assignment/domain/repository/JobRepository.java
@@ -2,6 +2,8 @@ package com.realteeth.assignment.domain.repository;
 
 import com.realteeth.assignment.domain.entity.Job;
 import com.realteeth.assignment.domain.enums.JobStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -17,6 +19,8 @@ public interface JobRepository extends JpaRepository<Job, Long> {
     List<Job> findByRequestHash(String requestHash);
 
     List<Job> findByStatus(JobStatus status);
+
+    Page<Job> findByStatus(JobStatus status, Pageable pageable);
 
     @Query(value = """
             SELECT * FROM jobs

--- a/src/main/java/com/realteeth/assignment/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/realteeth/assignment/exception/GlobalExceptionHandler.java
@@ -2,6 +2,8 @@ package com.realteeth.assignment.exception;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -17,6 +19,24 @@ public class GlobalExceptionHandler {
         } else {
             log.warn("Client error: {}", errorCode.getMessage());
         }
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ErrorResponse.of(errorCode));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidation(MethodArgumentNotValidException e) {
+        log.warn("Validation error: {}", e.getMessage());
+        ErrorCode errorCode = ErrorCode.INVALID_JOB_REQUEST;
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ErrorResponse.of(errorCode));
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponse> handleMessageNotReadable(HttpMessageNotReadableException e) {
+        log.warn("Message not readable: {}", e.getMessage());
+        ErrorCode errorCode = ErrorCode.INVALID_JOB_REQUEST;
         return ResponseEntity
                 .status(errorCode.getStatus())
                 .body(ErrorResponse.of(errorCode));

--- a/src/main/java/com/realteeth/assignment/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/realteeth/assignment/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @Slf4j
 @RestControllerAdvice
@@ -36,6 +37,15 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<ErrorResponse> handleMessageNotReadable(HttpMessageNotReadableException e) {
         log.warn("Message not readable: {}", e.getMessage());
+        ErrorCode errorCode = ErrorCode.INVALID_JOB_REQUEST;
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ErrorResponse.of(errorCode));
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleTypeMismatch(MethodArgumentTypeMismatchException e) {
+        log.warn("Type mismatch: {}", e.getMessage());
         ErrorCode errorCode = ErrorCode.INVALID_JOB_REQUEST;
         return ResponseEntity
                 .status(errorCode.getStatus())

--- a/src/main/java/com/realteeth/assignment/service/JobService.java
+++ b/src/main/java/com/realteeth/assignment/service/JobService.java
@@ -16,6 +16,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.HexFormat;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -30,14 +31,11 @@ public class JobService {
         String hash = calculateHash(imageUrl);
 
         List<Job> existing = jobRepository.findByRequestHash(hash);
-        boolean hasActive = existing.stream()
-                .anyMatch(j -> j.getStatus() != JobStatus.FAILED);
-        if (hasActive) {
-            Job activeJob = existing.stream()
-                    .filter(j -> j.getStatus() != JobStatus.FAILED)
-                    .findFirst()
-                    .orElseThrow();
-            return new JobSubmitResult(activeJob, false);
+        Optional<Job> activeJob = existing.stream()
+                .filter(j -> j.getStatus() != JobStatus.FAILED)
+                .findFirst();
+        if (activeJob.isPresent()) {
+            return new JobSubmitResult(activeJob.get(), false);
         }
 
         Job job = jobRepository.save(Job.create(imageUrl, hash));

--- a/src/main/java/com/realteeth/assignment/service/JobService.java
+++ b/src/main/java/com/realteeth/assignment/service/JobService.java
@@ -1,0 +1,68 @@
+package com.realteeth.assignment.service;
+
+import com.realteeth.assignment.domain.entity.Job;
+import com.realteeth.assignment.domain.enums.JobStatus;
+import com.realteeth.assignment.domain.repository.JobRepository;
+import com.realteeth.assignment.exception.ErrorCode;
+import com.realteeth.assignment.exception.JobException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class JobService {
+
+    private final JobRepository jobRepository;
+
+    @Transactional
+    public JobSubmitResult submitJob(String imageUrl) {
+        String hash = calculateHash(imageUrl);
+
+        List<Job> existing = jobRepository.findByRequestHash(hash);
+        boolean hasActive = existing.stream()
+                .anyMatch(j -> j.getStatus() != JobStatus.FAILED);
+        if (hasActive) {
+            Job activeJob = existing.stream()
+                    .filter(j -> j.getStatus() != JobStatus.FAILED)
+                    .findFirst()
+                    .orElseThrow();
+            return new JobSubmitResult(activeJob, false);
+        }
+
+        Job job = jobRepository.save(Job.create(imageUrl, hash));
+        return new JobSubmitResult(job, true);
+    }
+
+    public Job getJob(UUID jobId) {
+        return jobRepository.findByJobId(jobId)
+                .orElseThrow(() -> new JobException(ErrorCode.JOB_NOT_FOUND));
+    }
+
+    public Page<Job> getJobs(JobStatus status, Pageable pageable) {
+        if (status != null) {
+            return jobRepository.findByStatus(status, pageable);
+        }
+        return jobRepository.findAll(pageable);
+    }
+
+    private String calculateHash(String imageUrl) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] bytes = digest.digest(imageUrl.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(bytes);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("SHA-256 알고리즘을 찾을 수 없습니다.", e);
+        }
+    }
+}

--- a/src/main/java/com/realteeth/assignment/service/JobService.java
+++ b/src/main/java/com/realteeth/assignment/service/JobService.java
@@ -28,6 +28,9 @@ public class JobService {
 
     @Transactional
     public JobSubmitResult submitJob(String imageUrl) {
+        if (imageUrl == null || imageUrl.isBlank()) {
+            throw new JobException(ErrorCode.INVALID_JOB_REQUEST);
+        }
         String hash = calculateHash(imageUrl);
 
         List<Job> existing = jobRepository.findByRequestHash(hash);

--- a/src/main/java/com/realteeth/assignment/service/JobSubmitResult.java
+++ b/src/main/java/com/realteeth/assignment/service/JobSubmitResult.java
@@ -1,0 +1,5 @@
+package com.realteeth.assignment.service;
+
+import com.realteeth.assignment.domain.entity.Job;
+
+public record JobSubmitResult(Job job, boolean created) {}

--- a/src/test/java/com/realteeth/assignment/api/controller/JobControllerTest.java
+++ b/src/test/java/com/realteeth/assignment/api/controller/JobControllerTest.java
@@ -1,0 +1,145 @@
+package com.realteeth.assignment.api.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.realteeth.assignment.api.dto.JobSubmitRequest;
+import com.realteeth.assignment.domain.entity.Job;
+import com.realteeth.assignment.domain.enums.JobStatus;
+import com.realteeth.assignment.exception.ErrorCode;
+import com.realteeth.assignment.exception.JobException;
+import com.realteeth.assignment.service.JobService;
+import com.realteeth.assignment.service.JobSubmitResult;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(JobController.class)
+class JobControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @MockitoBean
+    private JobService jobService;
+
+    private static final String IMAGE_URL = "https://example.com/image.jpg";
+
+    @Test
+    void POST_잡_제출_신규_생성_시_201을_반환한다() throws Exception {
+        Job job = Job.create(IMAGE_URL, "hash");
+        given(jobService.submitJob(IMAGE_URL)).willReturn(new JobSubmitResult(job, true));
+
+        mockMvc.perform(post("/api/v1/jobs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new JobSubmitRequest(IMAGE_URL))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value("PENDING"))
+                .andExpect(jsonPath("$.imageUrl").value(IMAGE_URL));
+    }
+
+    @Test
+    void POST_잡_제출_중복_요청_시_200을_반환한다() throws Exception {
+        Job job = Job.create(IMAGE_URL, "hash");
+        given(jobService.submitJob(IMAGE_URL)).willReturn(new JobSubmitResult(job, false));
+
+        mockMvc.perform(post("/api/v1/jobs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new JobSubmitRequest(IMAGE_URL))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("PENDING"));
+    }
+
+    @Test
+    void POST_잡_제출_imageUrl이_빈_값이면_400을_반환한다() throws Exception {
+        mockMvc.perform(post("/api/v1/jobs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new JobSubmitRequest(""))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_JOB_REQUEST"));
+    }
+
+    @Test
+    void POST_잡_제출_imageUrl이_null이면_400을_반환한다() throws Exception {
+        mockMvc.perform(post("/api/v1/jobs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new JobSubmitRequest(null))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_JOB_REQUEST"));
+    }
+
+    @Test
+    void POST_잡_제출_요청_body가_없으면_400을_반환한다() throws Exception {
+        mockMvc.perform(post("/api/v1/jobs")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_JOB_REQUEST"));
+    }
+
+    @Test
+    void GET_단건_조회_존재하는_잡이면_200을_반환한다() throws Exception {
+        UUID jobId = UUID.randomUUID();
+        Job job = Job.create(IMAGE_URL, "hash");
+        given(jobService.getJob(jobId)).willReturn(job);
+
+        mockMvc.perform(get("/api/v1/jobs/{jobId}", jobId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("PENDING"))
+                .andExpect(jsonPath("$.imageUrl").value(IMAGE_URL));
+    }
+
+    @Test
+    void GET_단건_조회_존재하지_않는_잡이면_404를_반환한다() throws Exception {
+        UUID jobId = UUID.randomUUID();
+        given(jobService.getJob(jobId)).willThrow(new JobException(ErrorCode.JOB_NOT_FOUND));
+
+        mockMvc.perform(get("/api/v1/jobs/{jobId}", jobId))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("JOB_NOT_FOUND"));
+    }
+
+    @Test
+    void GET_목록_조회_기본_파라미터로_200을_반환한다() throws Exception {
+        Page<Job> page = new PageImpl<>(List.of(Job.create(IMAGE_URL, "hash")));
+        given(jobService.getJobs(eq(null), any(Pageable.class))).willReturn(page);
+
+        mockMvc.perform(get("/api/v1/jobs"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").isArray())
+                .andExpect(jsonPath("$.content[0].status").value("PENDING"));
+    }
+
+    @Test
+    void GET_목록_조회_status_필터로_조회한다() throws Exception {
+        Job job = Job.create(IMAGE_URL, "hash");
+        Page<Job> page = new PageImpl<>(List.of(job));
+        given(jobService.getJobs(eq(JobStatus.PENDING), any(Pageable.class))).willReturn(page);
+
+        mockMvc.perform(get("/api/v1/jobs").param("status", "PENDING"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].status").value("PENDING"));
+    }
+
+    @Test
+    void GET_목록_조회_잘못된_status_값이면_400을_반환한다() throws Exception {
+        mockMvc.perform(get("/api/v1/jobs").param("status", "INVALID_STATUS"))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/com/realteeth/assignment/service/JobServiceTest.java
+++ b/src/test/java/com/realteeth/assignment/service/JobServiceTest.java
@@ -24,8 +24,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
+
+import org.mockito.ArgumentCaptor;
 
 @ExtendWith(MockitoExtension.class)
 class JobServiceTest {
@@ -106,18 +107,33 @@ class JobServiceTest {
     }
 
     @Test
-    void submitJob은_동일한_imageUrl에_대해_동일한_해시를_생성한다() {
-        Job saved1 = Job.create(IMAGE_URL, "hash");
-        Job saved2 = Job.create(IMAGE_URL, "hash");
+    void submitJob은_동일한_imageUrl에_대해_동일한_해시로_조회한다() {
         given(jobRepository.findByRequestHash(anyString())).willReturn(List.of());
-        given(jobRepository.save(any(Job.class))).willReturn(saved1, saved2);
+        given(jobRepository.save(any(Job.class))).willReturn(Job.create(IMAGE_URL, "hash"));
 
         jobService.submitJob(IMAGE_URL);
         jobService.submitJob(IMAGE_URL);
 
-        // 두 번 호출 시 동일한 hash로 findByRequestHash 호출됨을 캡처로 확인 가능
-        // 여기서는 save가 두 번 호출됐음(FAILED 없으면 매번 빈 리스트 반환되므로)을 확인
-        verify(jobRepository, org.mockito.Mockito.times(2)).save(any(Job.class));
+        ArgumentCaptor<String> hashCaptor = ArgumentCaptor.forClass(String.class);
+        verify(jobRepository, times(2)).findByRequestHash(hashCaptor.capture());
+        List<String> hashes = hashCaptor.getAllValues();
+        assertThat(hashes.get(0)).isEqualTo(hashes.get(1));
+    }
+
+    @Test
+    void submitJob은_imageUrl이_null이면_INVALID_JOB_REQUEST_예외를_던진다() {
+        assertThatThrownBy(() -> jobService.submitJob(null))
+                .isInstanceOf(JobException.class)
+                .satisfies(e -> assertThat(((JobException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.INVALID_JOB_REQUEST));
+    }
+
+    @Test
+    void submitJob은_imageUrl이_빈_값이면_INVALID_JOB_REQUEST_예외를_던진다() {
+        assertThatThrownBy(() -> jobService.submitJob(""))
+                .isInstanceOf(JobException.class)
+                .satisfies(e -> assertThat(((JobException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.INVALID_JOB_REQUEST));
     }
 
     @Test

--- a/src/test/java/com/realteeth/assignment/service/JobServiceTest.java
+++ b/src/test/java/com/realteeth/assignment/service/JobServiceTest.java
@@ -1,0 +1,171 @@
+package com.realteeth.assignment.service;
+
+import com.realteeth.assignment.domain.entity.Job;
+import com.realteeth.assignment.domain.enums.JobStatus;
+import com.realteeth.assignment.domain.repository.JobRepository;
+import com.realteeth.assignment.exception.ErrorCode;
+import com.realteeth.assignment.exception.JobException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class JobServiceTest {
+
+    @Mock
+    private JobRepository jobRepository;
+
+    @InjectMocks
+    private JobService jobService;
+
+    private static final String IMAGE_URL = "https://example.com/image.jpg";
+
+    @Test
+    void submitJob은_새_잡을_생성하고_created_true를_반환한다() {
+        given(jobRepository.findByRequestHash(anyString())).willReturn(List.of());
+        Job saved = Job.create(IMAGE_URL, "hash");
+        given(jobRepository.save(any(Job.class))).willReturn(saved);
+
+        JobSubmitResult result = jobService.submitJob(IMAGE_URL);
+
+        assertThat(result.created()).isTrue();
+        assertThat(result.job()).isEqualTo(saved);
+        verify(jobRepository).save(any(Job.class));
+    }
+
+    @Test
+    void submitJob은_PENDING_잡이_존재하면_기존_잡을_반환하고_created_false를_반환한다() {
+        Job pending = Job.create(IMAGE_URL, "hash");
+        given(jobRepository.findByRequestHash(anyString())).willReturn(List.of(pending));
+
+        JobSubmitResult result = jobService.submitJob(IMAGE_URL);
+
+        assertThat(result.created()).isFalse();
+        assertThat(result.job()).isEqualTo(pending);
+        verify(jobRepository, never()).save(any());
+    }
+
+    @Test
+    void submitJob은_PROCESSING_잡이_존재하면_기존_잡을_반환하고_created_false를_반환한다() {
+        Job processing = Job.create(IMAGE_URL, "hash");
+        processing.markProcessing("worker-001");
+        given(jobRepository.findByRequestHash(anyString())).willReturn(List.of(processing));
+
+        JobSubmitResult result = jobService.submitJob(IMAGE_URL);
+
+        assertThat(result.created()).isFalse();
+        assertThat(result.job()).isEqualTo(processing);
+        verify(jobRepository, never()).save(any());
+    }
+
+    @Test
+    void submitJob은_COMPLETED_잡이_존재하면_기존_잡을_반환하고_created_false를_반환한다() {
+        Job completed = Job.create(IMAGE_URL, "hash");
+        completed.markProcessing("worker-001");
+        completed.markCompleted("{\"score\":0.9}");
+        given(jobRepository.findByRequestHash(anyString())).willReturn(List.of(completed));
+
+        JobSubmitResult result = jobService.submitJob(IMAGE_URL);
+
+        assertThat(result.created()).isFalse();
+        assertThat(result.job()).isEqualTo(completed);
+        verify(jobRepository, never()).save(any());
+    }
+
+    @Test
+    void submitJob은_FAILED_잡만_존재하면_새_잡을_생성한다() {
+        Job failed = Job.create(IMAGE_URL, "hash");
+        failed.markProcessing("worker-001");
+        failed.markFailed("error");
+        given(jobRepository.findByRequestHash(anyString())).willReturn(List.of(failed));
+        Job saved = Job.create(IMAGE_URL, "hash");
+        given(jobRepository.save(any(Job.class))).willReturn(saved);
+
+        JobSubmitResult result = jobService.submitJob(IMAGE_URL);
+
+        assertThat(result.created()).isTrue();
+        verify(jobRepository).save(any(Job.class));
+    }
+
+    @Test
+    void submitJob은_동일한_imageUrl에_대해_동일한_해시를_생성한다() {
+        Job saved1 = Job.create(IMAGE_URL, "hash");
+        Job saved2 = Job.create(IMAGE_URL, "hash");
+        given(jobRepository.findByRequestHash(anyString())).willReturn(List.of());
+        given(jobRepository.save(any(Job.class))).willReturn(saved1, saved2);
+
+        jobService.submitJob(IMAGE_URL);
+        jobService.submitJob(IMAGE_URL);
+
+        // 두 번 호출 시 동일한 hash로 findByRequestHash 호출됨을 캡처로 확인 가능
+        // 여기서는 save가 두 번 호출됐음(FAILED 없으면 매번 빈 리스트 반환되므로)을 확인
+        verify(jobRepository, org.mockito.Mockito.times(2)).save(any(Job.class));
+    }
+
+    @Test
+    void getJob은_jobId로_잡을_조회한다() {
+        UUID jobId = UUID.randomUUID();
+        Job job = Job.create(IMAGE_URL, "hash");
+        given(jobRepository.findByJobId(jobId)).willReturn(Optional.of(job));
+
+        Job found = jobService.getJob(jobId);
+
+        assertThat(found).isEqualTo(job);
+    }
+
+    @Test
+    void getJob은_존재하지_않는_jobId이면_JOB_NOT_FOUND_예외를_던진다() {
+        UUID jobId = UUID.randomUUID();
+        given(jobRepository.findByJobId(jobId)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> jobService.getJob(jobId))
+                .isInstanceOf(JobException.class)
+                .satisfies(e -> assertThat(((JobException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.JOB_NOT_FOUND));
+    }
+
+    @Test
+    void getJobs는_status가_null이면_전체_목록을_조회한다() {
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<Job> page = new PageImpl<>(List.of(Job.create(IMAGE_URL, "hash")));
+        given(jobRepository.findAll(pageable)).willReturn(page);
+
+        Page<Job> result = jobService.getJobs(null, pageable);
+
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        verify(jobRepository).findAll(pageable);
+        verify(jobRepository, never()).findByStatus(any(), any());
+    }
+
+    @Test
+    void getJobs는_status_필터로_목록을_조회한다() {
+        Pageable pageable = PageRequest.of(0, 10);
+        Job job = Job.create(IMAGE_URL, "hash");
+        Page<Job> page = new PageImpl<>(List.of(job));
+        given(jobRepository.findByStatus(JobStatus.PENDING, pageable)).willReturn(page);
+
+        Page<Job> result = jobService.getJobs(JobStatus.PENDING, pageable);
+
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        verify(jobRepository).findByStatus(JobStatus.PENDING, pageable);
+        verify(jobRepository, never()).findAll(any(Pageable.class));
+    }
+}


### PR DESCRIPTION
## 관련 이슈
closes #14

## 작업 내용

JobSubmitRequest / JobResponse

- `JobSubmitRequest` — `@NotBlank imageUrl` 필드를 가진 요청 record
- `JobResponse` — `jobId, status, imageUrl, result, errorMessage, createdAt, updatedAt` 응답 record, `from(Job)` 정적 팩토리

JobRepository

- `Page<Job> findByStatus(JobStatus, Pageable)` 메서드 추가 — status 필터 목록 조회용

JobService

- `submitJob(imageUrl)` — SHA-256 해시로 중복 감지, 활성 잡(PENDING/PROCESSING/COMPLETED) 존재 시 기존 잡 반환(`created=false`), FAILED만 있으면 새 잡 생성(`created=true`)
- `getJob(jobId)` — UUID로 단건 조회, 없으면 `JobException(JOB_NOT_FOUND)`
- `getJobs(status, pageable)` — status 있으면 필터 조회, 없으면 전체 조회
- `JobSubmitResult(job, created)` — 컨트롤러에서 201/200 응답 코드 구분용

JobController

- `POST /api/v1/jobs` — 신규 생성 201 / 중복 반환 200
- `GET /api/v1/jobs/{jobId}` — 단건 조회 200 / 없으면 404
- `GET /api/v1/jobs` — 목록 조회 (page, size, status), `createdAt` 내림차순 기본값

GlobalExceptionHandler

- `MethodArgumentNotValidException` 핸들러 추가 — `@Valid` 실패 시 INVALID_JOB_REQUEST (400)
- `HttpMessageNotReadableException` 핸들러 추가 — 잘못된 JSON 파싱 시 INVALID_JOB_REQUEST (400)
- `MethodArgumentTypeMismatchException` 핸들러 추가 — 잘못된 enum 파라미터 바인딩 시 INVALID_JOB_REQUEST (400)

기타

- `spring-boot-starter-validation` 의존성 추가

## 테스트

JobServiceTest (단위 테스트, Mockito)

- 신규 잡 생성 정상 동작
- PENDING/PROCESSING/COMPLETED 잡 존재 시 기존 잡 반환 (각 상태별)
- FAILED 잡만 존재 시 새 잡 생성
- 동일 imageUrl 동일 해시 생성 확인
- 존재하지 않는 jobId 조회 시 JOB_NOT_FOUND
- status=null 전체 목록 조회
- status 필터 목록 조회

JobControllerTest (@WebMvcTest 슬라이스 테스트)

- POST 신규 생성 201 / 중복 반환 200
- POST imageUrl 빈 값·null·body 없음 → 400
- GET 단건 조회 200 / 존재하지 않는 잡 404
- GET 목록 조회 기본·status 필터 200
- GET 잘못된 status 값 400