### PR TITLE
Feature/#6 JobDispatcher 구현 - PENDING 잡 Mock Worker 전송

### DIFF
--- a/src/main/java/com/realteeth/assignment/SchedulingConfig.java
+++ b/src/main/java/com/realteeth/assignment/SchedulingConfig.java
@@ -1,0 +1,11 @@
+package com.realteeth.assignment;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+@ConditionalOnProperty(name = "scheduling.enabled", havingValue = "true")
+public class SchedulingConfig {
+}

--- a/src/main/java/com/realteeth/assignment/domain/enums/JobStatus.java
+++ b/src/main/java/com/realteeth/assignment/domain/enums/JobStatus.java
@@ -10,7 +10,7 @@ public enum JobStatus {
     PENDING {
         @Override
         public Set<JobStatus> allowedNextStates() {
-            return Set.of(PROCESSING);
+            return Set.of(PROCESSING, FAILED);
         }
     },
     PROCESSING {

--- a/src/main/java/com/realteeth/assignment/service/JobDispatchProcessor.java
+++ b/src/main/java/com/realteeth/assignment/service/JobDispatchProcessor.java
@@ -1,0 +1,50 @@
+package com.realteeth.assignment.service;
+
+import com.realteeth.assignment.domain.entity.Job;
+import com.realteeth.assignment.domain.enums.JobStatus;
+import com.realteeth.assignment.domain.repository.JobRepository;
+import com.realteeth.assignment.exception.ErrorCode;
+import com.realteeth.assignment.exception.JobException;
+import com.realteeth.assignment.exception.MockWorkerException;
+import com.realteeth.assignment.worker.MockWorkerClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class JobDispatchProcessor {
+
+    private final JobRepository jobRepository;
+    private final MockWorkerClient mockWorkerClient;
+
+    @Transactional
+    public List<Job> fetchPendingJobs(int limit) {
+        return jobRepository.findPendingJobsForUpdate(limit);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void dispatchOne(Long jobId) {
+        Job job = jobRepository.findById(jobId)
+                .orElseThrow(() -> new JobException(ErrorCode.JOB_NOT_FOUND));
+
+        if (job.getStatus() != JobStatus.PENDING) {
+            log.info("잡이 이미 PENDING이 아님, 스킵 (id={}, status={})", jobId, job.getStatus());
+            return;
+        }
+
+        try {
+            MockWorkerClient.ProcessStartResponse response = mockWorkerClient.submitJob(job.getImageUrl());
+            job.markProcessing(response.jobId());
+            log.info("잡 디스패치 성공 (jobId={}, workerJobId={})", job.getJobId(), response.jobId());
+        } catch (MockWorkerException e) {
+            job.markFailed(e.getMessage());
+            log.warn("잡 디스패치 실패 (jobId={}): {}", job.getJobId(), e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/realteeth/assignment/service/JobDispatchProcessor.java
+++ b/src/main/java/com/realteeth/assignment/service/JobDispatchProcessor.java
@@ -29,22 +29,22 @@ public class JobDispatchProcessor {
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void dispatchOne(Long jobId) {
-        Job job = jobRepository.findById(jobId)
+    public void dispatchOne(Long id) {
+        Job job = jobRepository.findById(id)
                 .orElseThrow(() -> new JobException(ErrorCode.JOB_NOT_FOUND));
 
         if (job.getStatus() != JobStatus.PENDING) {
-            log.info("잡이 이미 PENDING이 아님, 스킵 (id={}, status={})", jobId, job.getStatus());
+            log.info("잡이 이미 PENDING이 아님, 스킵 (id={}, status={})", id, job.getStatus());
             return;
         }
 
         try {
             MockWorkerClient.ProcessStartResponse response = mockWorkerClient.submitJob(job.getImageUrl());
             job.markProcessing(response.jobId());
-            log.info("잡 디스패치 성공 (jobId={}, workerJobId={})", job.getJobId(), response.jobId());
+            log.info("잡 디스패치 성공 (id={}, jobId={}, workerJobId={})", id, job.getJobId(), response.jobId());
         } catch (MockWorkerException e) {
             job.markFailed(e.getMessage());
-            log.warn("잡 디스패치 실패 (jobId={}): {}", job.getJobId(), e.getMessage());
+            log.warn("잡 디스패치 실패 (id={}, jobId={}): {}", id, job.getJobId(), e.getMessage());
         }
     }
 }

--- a/src/main/java/com/realteeth/assignment/service/JobDispatcher.java
+++ b/src/main/java/com/realteeth/assignment/service/JobDispatcher.java
@@ -1,0 +1,33 @@
+package com.realteeth.assignment.service;
+
+import com.realteeth.assignment.domain.entity.Job;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class JobDispatcher {
+
+    private final JobDispatchProcessor jobDispatchProcessor;
+
+    @Value("${dispatch.batch-size:10}")
+    private int batchSize;
+
+    @Scheduled(fixedDelay = 3000)
+    public void dispatch() {
+        List<Job> pendingJobs = jobDispatchProcessor.fetchPendingJobs(batchSize);
+        for (Job job : pendingJobs) {
+            try {
+                jobDispatchProcessor.dispatchOne(job.getId());
+            } catch (Exception e) {
+                log.error("잡 디스패치 중 예외 발생 (jobId={}): {}", job.getJobId(), e.getMessage(), e);
+            }
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,9 @@ spring:
 scheduling:
   enabled: true
 
+dispatch:
+  batch-size: 10
+
 mock-worker:
   base-url: https://dev.realteeth.ai/mock
   candidate-name: ${MOCK_WORKER_CANDIDATE_NAME}

--- a/src/test/java/com/realteeth/assignment/domain/JobStatusTest.java
+++ b/src/test/java/com/realteeth/assignment/domain/JobStatusTest.java
@@ -39,11 +39,9 @@ class JobStatusTest {
     }
 
     @Test
-    void PENDING에서_FAILED로_전이하면_예외가_발생한다() {
-        assertThatThrownBy(() -> JobStatus.PENDING.transitionTo(JobStatus.FAILED))
-                .isInstanceOf(JobException.class)
-                .satisfies(e -> assertThat(((JobException) e).getErrorCode())
-                        .isEqualTo(ErrorCode.INVALID_STATE_TRANSITION));
+    void PENDING에서_FAILED로_전이된다() {
+        assertThat(JobStatus.PENDING.transitionTo(JobStatus.FAILED))
+                .isEqualTo(JobStatus.FAILED);
     }
 
     @ParameterizedTest

--- a/src/test/java/com/realteeth/assignment/domain/JobTest.java
+++ b/src/test/java/com/realteeth/assignment/domain/JobTest.java
@@ -72,11 +72,13 @@ class JobTest {
     }
 
     @Test
-    void PENDING_상태에서_markFailed_호출_시_예외가_발생한다() {
+    void PENDING_상태에서_markFailed는_FAILED로_전이하고_errorMessage를_설정한다() {
         Job job = Job.create("https://example.com/image.jpg", "abc123hash");
 
-        assertThatThrownBy(() -> job.markFailed("error"))
-                .isInstanceOf(JobException.class);
+        job.markFailed("디스패치 실패");
+
+        assertThat(job.getStatus()).isEqualTo(JobStatus.FAILED);
+        assertThat(job.getErrorMessage()).isEqualTo("디스패치 실패");
     }
 
     @Test

--- a/src/test/java/com/realteeth/assignment/service/JobDispatchProcessorTest.java
+++ b/src/test/java/com/realteeth/assignment/service/JobDispatchProcessorTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
 import java.util.Optional;
@@ -35,6 +36,12 @@ class JobDispatchProcessorTest {
 
     private static final String IMAGE_URL = "https://example.com/image.jpg";
 
+    private Job createJobWithId(Long id) {
+        Job job = Job.create(IMAGE_URL, "hash");
+        ReflectionTestUtils.setField(job, "id", id);
+        return job;
+    }
+
     @Test
     void fetchPendingJobs는_리포지토리에_limit을_전달하고_결과를_반환한다() {
         Job job = Job.create(IMAGE_URL, "hash");
@@ -48,12 +55,12 @@ class JobDispatchProcessorTest {
 
     @Test
     void submitJob_성공_시_잡을_PROCESSING으로_전이하고_workerJobId를_설정한다() {
-        Job job = Job.create(IMAGE_URL, "hash");
-        given(jobRepository.findById(job.getId())).willReturn(Optional.of(job));
+        Job job = createJobWithId(1L);
+        given(jobRepository.findById(1L)).willReturn(Optional.of(job));
         given(mockWorkerClient.submitJob(IMAGE_URL))
                 .willReturn(new MockWorkerClient.ProcessStartResponse("worker-001", "PROCESSING"));
 
-        jobDispatchProcessor.dispatchOne(job.getId());
+        jobDispatchProcessor.dispatchOne(1L);
 
         assertThat(job.getStatus()).isEqualTo(JobStatus.PROCESSING);
         assertThat(job.getWorkerJobId()).isEqualTo("worker-001");
@@ -61,12 +68,12 @@ class JobDispatchProcessorTest {
 
     @Test
     void MockWorkerException_발생_시_잡을_FAILED로_전이하고_errorMessage를_설정한다() {
-        Job job = Job.create(IMAGE_URL, "hash");
-        given(jobRepository.findById(job.getId())).willReturn(Optional.of(job));
+        Job job = createJobWithId(1L);
+        given(jobRepository.findById(1L)).willReturn(Optional.of(job));
         given(mockWorkerClient.submitJob(IMAGE_URL))
                 .willThrow(new MockWorkerException(ErrorCode.MOCK_WORKER_ERROR));
 
-        jobDispatchProcessor.dispatchOne(job.getId());
+        jobDispatchProcessor.dispatchOne(1L);
 
         assertThat(job.getStatus()).isEqualTo(JobStatus.FAILED);
         assertThat(job.getErrorMessage()).isNotNull();
@@ -84,11 +91,11 @@ class JobDispatchProcessorTest {
 
     @Test
     void 잡이_이미_PROCESSING_상태이면_submitJob을_호출하지_않는다() {
-        Job job = Job.create(IMAGE_URL, "hash");
+        Job job = createJobWithId(1L);
         job.markProcessing("worker-existing");
-        given(jobRepository.findById(job.getId())).willReturn(Optional.of(job));
+        given(jobRepository.findById(1L)).willReturn(Optional.of(job));
 
-        jobDispatchProcessor.dispatchOne(job.getId());
+        jobDispatchProcessor.dispatchOne(1L);
 
         verify(mockWorkerClient, never()).submitJob(any());
         assertThat(job.getStatus()).isEqualTo(JobStatus.PROCESSING);
@@ -96,12 +103,12 @@ class JobDispatchProcessorTest {
 
     @Test
     void 잡이_이미_COMPLETED_상태이면_submitJob을_호출하지_않는다() {
-        Job job = Job.create(IMAGE_URL, "hash");
+        Job job = createJobWithId(1L);
         job.markProcessing("worker-existing");
         job.markCompleted("{\"score\":0.9}");
-        given(jobRepository.findById(job.getId())).willReturn(Optional.of(job));
+        given(jobRepository.findById(1L)).willReturn(Optional.of(job));
 
-        jobDispatchProcessor.dispatchOne(job.getId());
+        jobDispatchProcessor.dispatchOne(1L);
 
         verify(mockWorkerClient, never()).submitJob(any());
         assertThat(job.getStatus()).isEqualTo(JobStatus.COMPLETED);

--- a/src/test/java/com/realteeth/assignment/service/JobDispatchProcessorTest.java
+++ b/src/test/java/com/realteeth/assignment/service/JobDispatchProcessorTest.java
@@ -1,0 +1,109 @@
+package com.realteeth.assignment.service;
+
+import com.realteeth.assignment.domain.entity.Job;
+import com.realteeth.assignment.domain.enums.JobStatus;
+import com.realteeth.assignment.domain.repository.JobRepository;
+import com.realteeth.assignment.exception.ErrorCode;
+import com.realteeth.assignment.exception.JobException;
+import com.realteeth.assignment.exception.MockWorkerException;
+import com.realteeth.assignment.worker.MockWorkerClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class JobDispatchProcessorTest {
+
+    @Mock
+    private JobRepository jobRepository;
+
+    @Mock
+    private MockWorkerClient mockWorkerClient;
+
+    @InjectMocks
+    private JobDispatchProcessor jobDispatchProcessor;
+
+    private static final String IMAGE_URL = "https://example.com/image.jpg";
+
+    @Test
+    void fetchPendingJobs는_리포지토리에_limit을_전달하고_결과를_반환한다() {
+        Job job = Job.create(IMAGE_URL, "hash");
+        given(jobRepository.findPendingJobsForUpdate(5)).willReturn(List.of(job));
+
+        List<Job> result = jobDispatchProcessor.fetchPendingJobs(5);
+
+        assertThat(result).containsExactly(job);
+        verify(jobRepository).findPendingJobsForUpdate(5);
+    }
+
+    @Test
+    void submitJob_성공_시_잡을_PROCESSING으로_전이하고_workerJobId를_설정한다() {
+        Job job = Job.create(IMAGE_URL, "hash");
+        given(jobRepository.findById(job.getId())).willReturn(Optional.of(job));
+        given(mockWorkerClient.submitJob(IMAGE_URL))
+                .willReturn(new MockWorkerClient.ProcessStartResponse("worker-001", "PROCESSING"));
+
+        jobDispatchProcessor.dispatchOne(job.getId());
+
+        assertThat(job.getStatus()).isEqualTo(JobStatus.PROCESSING);
+        assertThat(job.getWorkerJobId()).isEqualTo("worker-001");
+    }
+
+    @Test
+    void MockWorkerException_발생_시_잡을_FAILED로_전이하고_errorMessage를_설정한다() {
+        Job job = Job.create(IMAGE_URL, "hash");
+        given(jobRepository.findById(job.getId())).willReturn(Optional.of(job));
+        given(mockWorkerClient.submitJob(IMAGE_URL))
+                .willThrow(new MockWorkerException(ErrorCode.MOCK_WORKER_ERROR));
+
+        jobDispatchProcessor.dispatchOne(job.getId());
+
+        assertThat(job.getStatus()).isEqualTo(JobStatus.FAILED);
+        assertThat(job.getErrorMessage()).isNotNull();
+    }
+
+    @Test
+    void 잡이_존재하지_않으면_JOB_NOT_FOUND_예외를_던진다() {
+        given(jobRepository.findById(99L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> jobDispatchProcessor.dispatchOne(99L))
+                .isInstanceOf(JobException.class)
+                .satisfies(e -> assertThat(((JobException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.JOB_NOT_FOUND));
+    }
+
+    @Test
+    void 잡이_이미_PROCESSING_상태이면_submitJob을_호출하지_않는다() {
+        Job job = Job.create(IMAGE_URL, "hash");
+        job.markProcessing("worker-existing");
+        given(jobRepository.findById(job.getId())).willReturn(Optional.of(job));
+
+        jobDispatchProcessor.dispatchOne(job.getId());
+
+        verify(mockWorkerClient, never()).submitJob(any());
+        assertThat(job.getStatus()).isEqualTo(JobStatus.PROCESSING);
+    }
+
+    @Test
+    void 잡이_이미_COMPLETED_상태이면_submitJob을_호출하지_않는다() {
+        Job job = Job.create(IMAGE_URL, "hash");
+        job.markProcessing("worker-existing");
+        job.markCompleted("{\"score\":0.9}");
+        given(jobRepository.findById(job.getId())).willReturn(Optional.of(job));
+
+        jobDispatchProcessor.dispatchOne(job.getId());
+
+        verify(mockWorkerClient, never()).submitJob(any());
+        assertThat(job.getStatus()).isEqualTo(JobStatus.COMPLETED);
+    }
+}

--- a/src/test/java/com/realteeth/assignment/service/JobDispatcherTest.java
+++ b/src/test/java/com/realteeth/assignment/service/JobDispatcherTest.java
@@ -1,0 +1,65 @@
+package com.realteeth.assignment.service;
+
+import com.realteeth.assignment.domain.entity.Job;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class JobDispatcherTest {
+
+    @Mock
+    private JobDispatchProcessor jobDispatchProcessor;
+
+    @InjectMocks
+    private JobDispatcher jobDispatcher;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(jobDispatcher, "batchSize", 10);
+    }
+
+    @Test
+    void PENDING_잡이_있으면_각각_dispatchOne을_호출한다() {
+        Job job1 = Job.create("https://example.com/a.jpg", "hash1");
+        Job job2 = Job.create("https://example.com/b.jpg", "hash2");
+        given(jobDispatchProcessor.fetchPendingJobs(10)).willReturn(List.of(job1, job2));
+
+        jobDispatcher.dispatch();
+
+        verify(jobDispatchProcessor).dispatchOne(job1.getId());
+        verify(jobDispatchProcessor).dispatchOne(job2.getId());
+    }
+
+    @Test
+    void PENDING_잡이_없으면_dispatchOne을_호출하지_않는다() {
+        given(jobDispatchProcessor.fetchPendingJobs(anyInt())).willReturn(List.of());
+
+        jobDispatcher.dispatch();
+
+        verify(jobDispatchProcessor, never()).dispatchOne(any());
+    }
+
+    @Test
+    void dispatchOne에서_예외가_발생해도_다음_잡_처리를_계속한다() {
+        Job job1 = Job.create("https://example.com/a.jpg", "hash1");
+        Job job2 = Job.create("https://example.com/b.jpg", "hash2");
+        given(jobDispatchProcessor.fetchPendingJobs(10)).willReturn(List.of(job1, job2));
+        doThrow(new RuntimeException("디스패치 실패")).when(jobDispatchProcessor).dispatchOne(job1.getId());
+
+        jobDispatcher.dispatch();
+
+        verify(jobDispatchProcessor).dispatchOne(job1.getId());
+        verify(jobDispatchProcessor).dispatchOne(job2.getId());
+    }
+}

--- a/src/test/java/com/realteeth/assignment/service/JobDispatcherTest.java
+++ b/src/test/java/com/realteeth/assignment/service/JobDispatcherTest.java
@@ -29,16 +29,22 @@ class JobDispatcherTest {
         ReflectionTestUtils.setField(jobDispatcher, "batchSize", 10);
     }
 
+    private Job createJobWithId(String imageUrl, String hash, Long id) {
+        Job job = Job.create(imageUrl, hash);
+        ReflectionTestUtils.setField(job, "id", id);
+        return job;
+    }
+
     @Test
     void PENDING_잡이_있으면_각각_dispatchOne을_호출한다() {
-        Job job1 = Job.create("https://example.com/a.jpg", "hash1");
-        Job job2 = Job.create("https://example.com/b.jpg", "hash2");
+        Job job1 = createJobWithId("https://example.com/a.jpg", "hash1", 1L);
+        Job job2 = createJobWithId("https://example.com/b.jpg", "hash2", 2L);
         given(jobDispatchProcessor.fetchPendingJobs(10)).willReturn(List.of(job1, job2));
 
         jobDispatcher.dispatch();
 
-        verify(jobDispatchProcessor).dispatchOne(job1.getId());
-        verify(jobDispatchProcessor).dispatchOne(job2.getId());
+        verify(jobDispatchProcessor).dispatchOne(1L);
+        verify(jobDispatchProcessor).dispatchOne(2L);
     }
 
     @Test
@@ -52,14 +58,14 @@ class JobDispatcherTest {
 
     @Test
     void dispatchOne에서_예외가_발생해도_다음_잡_처리를_계속한다() {
-        Job job1 = Job.create("https://example.com/a.jpg", "hash1");
-        Job job2 = Job.create("https://example.com/b.jpg", "hash2");
+        Job job1 = createJobWithId("https://example.com/a.jpg", "hash1", 1L);
+        Job job2 = createJobWithId("https://example.com/b.jpg", "hash2", 2L);
         given(jobDispatchProcessor.fetchPendingJobs(10)).willReturn(List.of(job1, job2));
-        doThrow(new RuntimeException("디스패치 실패")).when(jobDispatchProcessor).dispatchOne(job1.getId());
+        doThrow(new RuntimeException("디스패치 실패")).when(jobDispatchProcessor).dispatchOne(1L);
 
         jobDispatcher.dispatch();
 
-        verify(jobDispatchProcessor).dispatchOne(job1.getId());
-        verify(jobDispatchProcessor).dispatchOne(job2.getId());
+        verify(jobDispatchProcessor).dispatchOne(1L);
+        verify(jobDispatchProcessor).dispatchOne(2L);
     }
 }


### PR DESCRIPTION
## 관련 이슈
closes #6

## 작업 내용

JobStatus

- `PENDING → FAILED` 전이 허용 — 디스패치 실패 시 MockWorkerClient가 retry/circuit breaker를 모두 소진한 후 예외를 전파하므로 FAILED로 확정 처리

SchedulingConfig

- `@EnableScheduling` + `@ConditionalOnProperty(name = "scheduling.enabled", havingValue = "true")` — 테스트 환경(`application.yml`에 `scheduling.enabled` 미설정)에서 스케줄링 자동 비활성화

JobDispatchProcessor

- `fetchPendingJobs(int limit)` — `@Transactional`, `SELECT ... FOR UPDATE SKIP LOCKED`로 PENDING 잡 조회
- `dispatchOne(Long jobId)` — `@Transactional(REQUIRES_NEW)`, 잡별 독립 트랜잭션으로 한 건 실패가 다른 건에 영향을 주지 않도록 격리
  - `findById`로 재조회(새 트랜잭션 영속성 컨텍스트)
  - PENDING 아닌 잡 스킵(경합 방어)
  - `MockWorkerClient.submitJob()` 성공 → `markProcessing(workerJobId)`, 실패(`MockWorkerException`) → `markFailed(errorMessage)`

JobDispatcher

- `@Scheduled(fixedDelay = 3000)` — 3초 주기, 이전 실행 완료 후 측정
- `@Value("${dispatch.batch-size:10}")` — 배치 사이즈 외부 설정
- 잡별 `try-catch`로 루프 중단 방지

## 테스트

JobDispatchProcessorTest (단위 테스트, Mockito)

- `submitJob` 성공 시 PROCESSING 전이 및 `workerJobId` 설정
- `MockWorkerException` 발생 시 FAILED 전이 및 `errorMessage` 설정
- 잡 미존재 시 `JOB_NOT_FOUND` 예외
- 이미 PROCESSING/COMPLETED 상태인 잡 스킵(경합 방어)

JobDispatcherTest (단위 테스트, Mockito)

- PENDING 잡이 있으면 각각 `dispatchOne` 호출
- PENDING 잡이 없으면 `dispatchOne` 미호출
- `dispatchOne` 예외 발생 시 다음 잡 계속 처리(장애 격리)