### PR TITLE
Feature/#7 JobPoller 구현 - PROCESSING 잡 상태 폴링

### DIFF
--- a/src/main/java/com/realteeth/assignment/domain/repository/JobRepository.java
+++ b/src/main/java/com/realteeth/assignment/domain/repository/JobRepository.java
@@ -29,13 +29,13 @@ public interface JobRepository extends JpaRepository<Job, Long> {
             LIMIT :limit
             FOR UPDATE SKIP LOCKED
             """, nativeQuery = true)
-    List<Job> findPendingJobsForUpdate(@Param("status") String status, @Param("limit") int limit);
+    List<Job> findJobsByStatusForUpdate(@Param("status") String status, @Param("limit") int limit);
 
     default List<Job> findPendingJobsForUpdate(int limit) {
-        return findPendingJobsForUpdate(JobStatus.PENDING.name(), limit);
+        return findJobsByStatusForUpdate(JobStatus.PENDING.name(), limit);
     }
 
     default List<Job> findProcessingJobsForUpdate(int limit) {
-        return findPendingJobsForUpdate(JobStatus.PROCESSING.name(), limit);
+        return findJobsByStatusForUpdate(JobStatus.PROCESSING.name(), limit);
     }
 }

--- a/src/main/java/com/realteeth/assignment/domain/repository/JobRepository.java
+++ b/src/main/java/com/realteeth/assignment/domain/repository/JobRepository.java
@@ -34,4 +34,8 @@ public interface JobRepository extends JpaRepository<Job, Long> {
     default List<Job> findPendingJobsForUpdate(int limit) {
         return findPendingJobsForUpdate(JobStatus.PENDING.name(), limit);
     }
+
+    default List<Job> findProcessingJobsForUpdate(int limit) {
+        return findPendingJobsForUpdate(JobStatus.PROCESSING.name(), limit);
+    }
 }

--- a/src/main/java/com/realteeth/assignment/service/JobDispatcher.java
+++ b/src/main/java/com/realteeth/assignment/service/JobDispatcher.java
@@ -26,7 +26,7 @@ public class JobDispatcher {
             try {
                 jobDispatchProcessor.dispatchOne(job.getId());
             } catch (Exception e) {
-                log.error("잡 디스패치 중 예외 발생 (jobId={}): {}", job.getJobId(), e.getMessage(), e);
+                log.error("잡 디스패치 중 예외 발생 (id={}, jobId={}): {}", job.getId(), job.getJobId(), e.getMessage(), e);
             }
         }
     }

--- a/src/main/java/com/realteeth/assignment/service/JobPollProcessor.java
+++ b/src/main/java/com/realteeth/assignment/service/JobPollProcessor.java
@@ -1,0 +1,59 @@
+package com.realteeth.assignment.service;
+
+import com.realteeth.assignment.domain.entity.Job;
+import com.realteeth.assignment.domain.enums.JobStatus;
+import com.realteeth.assignment.domain.repository.JobRepository;
+import com.realteeth.assignment.exception.ErrorCode;
+import com.realteeth.assignment.exception.JobException;
+import com.realteeth.assignment.exception.MockWorkerException;
+import com.realteeth.assignment.worker.MockWorkerClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class JobPollProcessor {
+
+    private final JobRepository jobRepository;
+    private final MockWorkerClient mockWorkerClient;
+
+    @Transactional
+    public List<Job> fetchProcessingJobs(int limit) {
+        return jobRepository.findProcessingJobsForUpdate(limit);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void pollOne(Long id) {
+        Job job = jobRepository.findById(id)
+                .orElseThrow(() -> new JobException(ErrorCode.JOB_NOT_FOUND));
+
+        if (job.getStatus() != JobStatus.PROCESSING) {
+            log.info("잡이 이미 PROCESSING이 아님, 스킵 (id={}, status={})", id, job.getStatus());
+            return;
+        }
+
+        try {
+            MockWorkerClient.ProcessStatusResponse response = mockWorkerClient.getJobStatus(job.getWorkerJobId());
+            switch (response.status()) {
+                case "COMPLETED" -> {
+                    job.markCompleted(response.result());
+                    log.info("잡 COMPLETED 전이 (id={}, jobId={})", id, job.getJobId());
+                }
+                case "FAILED" -> {
+                    String errorMessage = response.result() != null ? response.result() : "Worker processing failed";
+                    job.markFailed(errorMessage);
+                    log.info("잡 FAILED 전이 (id={}, jobId={}): {}", id, job.getJobId(), errorMessage);
+                }
+                default -> log.debug("잡 아직 PROCESSING 중 (id={}, jobId={})", id, job.getJobId());
+            }
+        } catch (MockWorkerException e) {
+            log.warn("잡 폴링 실패, 다음 주기에 재시도 (id={}, jobId={}): {}", id, job.getJobId(), e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/realteeth/assignment/service/JobPoller.java
+++ b/src/main/java/com/realteeth/assignment/service/JobPoller.java
@@ -1,0 +1,33 @@
+package com.realteeth.assignment.service;
+
+import com.realteeth.assignment.domain.entity.Job;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class JobPoller {
+
+    private final JobPollProcessor jobPollProcessor;
+
+    @Value("${polling.batch-size:10}")
+    private int batchSize;
+
+    @Scheduled(fixedDelay = 5000)
+    public void poll() {
+        List<Job> processingJobs = jobPollProcessor.fetchProcessingJobs(batchSize);
+        for (Job job : processingJobs) {
+            try {
+                jobPollProcessor.pollOne(job.getId());
+            } catch (Exception e) {
+                log.error("잡 폴링 중 예외 발생 (jobId={}): {}", job.getJobId(), e.getMessage(), e);
+            }
+        }
+    }
+}

--- a/src/main/java/com/realteeth/assignment/service/JobPoller.java
+++ b/src/main/java/com/realteeth/assignment/service/JobPoller.java
@@ -26,7 +26,7 @@ public class JobPoller {
             try {
                 jobPollProcessor.pollOne(job.getId());
             } catch (Exception e) {
-                log.error("잡 폴링 중 예외 발생 (jobId={}): {}", job.getJobId(), e.getMessage(), e);
+                log.error("잡 폴링 중 예외 발생 (id={}, jobId={}): {}", job.getId(), job.getJobId(), e.getMessage(), e);
             }
         }
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,6 +20,9 @@ scheduling:
 dispatch:
   batch-size: 10
 
+polling:
+  batch-size: 10
+
 mock-worker:
   base-url: https://dev.realteeth.ai/mock
   candidate-name: ${MOCK_WORKER_CANDIDATE_NAME}

--- a/src/test/java/com/realteeth/assignment/service/JobDispatcherTest.java
+++ b/src/test/java/com/realteeth/assignment/service/JobDispatcherTest.java
@@ -12,6 +12,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
@@ -53,7 +54,7 @@ class JobDispatcherTest {
 
         jobDispatcher.dispatch();
 
-        verify(jobDispatchProcessor, never()).dispatchOne(any());
+        verify(jobDispatchProcessor, never()).dispatchOne(anyLong());
     }
 
     @Test

--- a/src/test/java/com/realteeth/assignment/service/JobPollProcessorTest.java
+++ b/src/test/java/com/realteeth/assignment/service/JobPollProcessorTest.java
@@ -1,0 +1,142 @@
+package com.realteeth.assignment.service;
+
+import com.realteeth.assignment.domain.entity.Job;
+import com.realteeth.assignment.domain.enums.JobStatus;
+import com.realteeth.assignment.domain.repository.JobRepository;
+import com.realteeth.assignment.exception.ErrorCode;
+import com.realteeth.assignment.exception.JobException;
+import com.realteeth.assignment.exception.MockWorkerException;
+import com.realteeth.assignment.worker.MockWorkerClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class JobPollProcessorTest {
+
+    @Mock
+    private JobRepository jobRepository;
+
+    @Mock
+    private MockWorkerClient mockWorkerClient;
+
+    @InjectMocks
+    private JobPollProcessor jobPollProcessor;
+
+    private static final String IMAGE_URL = "https://example.com/image.jpg";
+    private static final String WORKER_JOB_ID = "worker-001";
+
+    private Job createProcessingJobWithId(Long id) {
+        Job job = Job.create(IMAGE_URL, "hash");
+        ReflectionTestUtils.setField(job, "id", id);
+        job.markProcessing(WORKER_JOB_ID);
+        return job;
+    }
+
+    @Test
+    void fetchProcessingJobs는_리포지토리에_limit을_전달하고_결과를_반환한다() {
+        Job job = createProcessingJobWithId(1L);
+        given(jobRepository.findProcessingJobsForUpdate(5)).willReturn(List.of(job));
+
+        List<Job> result = jobPollProcessor.fetchProcessingJobs(5);
+
+        assertThat(result).containsExactly(job);
+        verify(jobRepository).findProcessingJobsForUpdate(5);
+    }
+
+    @Test
+    void Worker가_COMPLETED를_반환하면_잡을_COMPLETED로_전이하고_result를_설정한다() {
+        Job job = createProcessingJobWithId(1L);
+        given(jobRepository.findById(1L)).willReturn(Optional.of(job));
+        given(mockWorkerClient.getJobStatus(WORKER_JOB_ID))
+                .willReturn(new MockWorkerClient.ProcessStatusResponse(WORKER_JOB_ID, "COMPLETED", "{\"score\":0.9}"));
+
+        jobPollProcessor.pollOne(1L);
+
+        assertThat(job.getStatus()).isEqualTo(JobStatus.COMPLETED);
+        assertThat(job.getResult()).isEqualTo("{\"score\":0.9}");
+    }
+
+    @Test
+    void Worker가_FAILED를_반환하면_잡을_FAILED로_전이하고_errorMessage를_설정한다() {
+        Job job = createProcessingJobWithId(1L);
+        given(jobRepository.findById(1L)).willReturn(Optional.of(job));
+        given(mockWorkerClient.getJobStatus(WORKER_JOB_ID))
+                .willReturn(new MockWorkerClient.ProcessStatusResponse(WORKER_JOB_ID, "FAILED", null));
+
+        jobPollProcessor.pollOne(1L);
+
+        assertThat(job.getStatus()).isEqualTo(JobStatus.FAILED);
+        assertThat(job.getErrorMessage()).isNotNull();
+    }
+
+    @Test
+    void Worker가_PROCESSING을_반환하면_잡_상태를_변경하지_않는다() {
+        Job job = createProcessingJobWithId(1L);
+        given(jobRepository.findById(1L)).willReturn(Optional.of(job));
+        given(mockWorkerClient.getJobStatus(WORKER_JOB_ID))
+                .willReturn(new MockWorkerClient.ProcessStatusResponse(WORKER_JOB_ID, "PROCESSING", null));
+
+        jobPollProcessor.pollOne(1L);
+
+        assertThat(job.getStatus()).isEqualTo(JobStatus.PROCESSING);
+    }
+
+    @Test
+    void MockWorkerException_발생_시_잡_상태를_PROCESSING으로_유지한다() {
+        Job job = createProcessingJobWithId(1L);
+        given(jobRepository.findById(1L)).willReturn(Optional.of(job));
+        given(mockWorkerClient.getJobStatus(WORKER_JOB_ID))
+                .willThrow(new MockWorkerException(ErrorCode.MOCK_WORKER_ERROR));
+
+        jobPollProcessor.pollOne(1L);
+
+        assertThat(job.getStatus()).isEqualTo(JobStatus.PROCESSING);
+    }
+
+    @Test
+    void 잡이_존재하지_않으면_JOB_NOT_FOUND_예외를_던진다() {
+        given(jobRepository.findById(99L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> jobPollProcessor.pollOne(99L))
+                .isInstanceOf(JobException.class)
+                .satisfies(e -> assertThat(((JobException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.JOB_NOT_FOUND));
+    }
+
+    @Test
+    void 잡이_이미_COMPLETED_상태이면_getJobStatus를_호출하지_않는다() {
+        Job job = createProcessingJobWithId(1L);
+        job.markCompleted("{\"score\":0.9}");
+        given(jobRepository.findById(1L)).willReturn(Optional.of(job));
+
+        jobPollProcessor.pollOne(1L);
+
+        verify(mockWorkerClient, never()).getJobStatus(any());
+        assertThat(job.getStatus()).isEqualTo(JobStatus.COMPLETED);
+    }
+
+    @Test
+    void 잡이_이미_FAILED_상태이면_getJobStatus를_호출하지_않는다() {
+        Job job = Job.create(IMAGE_URL, "hash");
+        ReflectionTestUtils.setField(job, "id", 1L);
+        job.markFailed("이전 실패");
+        given(jobRepository.findById(1L)).willReturn(Optional.of(job));
+
+        jobPollProcessor.pollOne(1L);
+
+        verify(mockWorkerClient, never()).getJobStatus(any());
+        assertThat(job.getStatus()).isEqualTo(JobStatus.FAILED);
+    }
+}

--- a/src/test/java/com/realteeth/assignment/service/JobPollerTest.java
+++ b/src/test/java/com/realteeth/assignment/service/JobPollerTest.java
@@ -1,0 +1,72 @@
+package com.realteeth.assignment.service;
+
+import com.realteeth.assignment.domain.entity.Job;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class JobPollerTest {
+
+    @Mock
+    private JobPollProcessor jobPollProcessor;
+
+    @InjectMocks
+    private JobPoller jobPoller;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(jobPoller, "batchSize", 10);
+    }
+
+    private Job createJobWithId(Long id) {
+        Job job = Job.create("https://example.com/image.jpg", "hash");
+        ReflectionTestUtils.setField(job, "id", id);
+        job.markProcessing("worker-" + id);
+        return job;
+    }
+
+    @Test
+    void PROCESSING_잡이_있으면_각각_pollOne을_호출한다() {
+        Job job1 = createJobWithId(1L);
+        Job job2 = createJobWithId(2L);
+        given(jobPollProcessor.fetchProcessingJobs(10)).willReturn(List.of(job1, job2));
+
+        jobPoller.poll();
+
+        verify(jobPollProcessor).pollOne(1L);
+        verify(jobPollProcessor).pollOne(2L);
+    }
+
+    @Test
+    void PROCESSING_잡이_없으면_pollOne을_호출하지_않는다() {
+        given(jobPollProcessor.fetchProcessingJobs(anyInt())).willReturn(List.of());
+
+        jobPoller.poll();
+
+        verify(jobPollProcessor, never()).pollOne(any());
+    }
+
+    @Test
+    void pollOne에서_예외가_발생해도_다음_잡_처리를_계속한다() {
+        Job job1 = createJobWithId(1L);
+        Job job2 = createJobWithId(2L);
+        given(jobPollProcessor.fetchProcessingJobs(10)).willReturn(List.of(job1, job2));
+        doThrow(new RuntimeException("폴링 실패")).when(jobPollProcessor).pollOne(1L);
+
+        jobPoller.poll();
+
+        verify(jobPollProcessor).pollOne(1L);
+        verify(jobPollProcessor).pollOne(2L);
+    }
+}

--- a/src/test/java/com/realteeth/assignment/service/JobPollerTest.java
+++ b/src/test/java/com/realteeth/assignment/service/JobPollerTest.java
@@ -12,6 +12,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
@@ -54,7 +55,7 @@ class JobPollerTest {
 
         jobPoller.poll();
 
-        verify(jobPollProcessor, never()).pollOne(any());
+        verify(jobPollProcessor, never()).pollOne(anyLong());
     }
 
     @Test


### PR DESCRIPTION
## 관련 이슈
closes #7

## 작업 내용

JobRepository

- `findProcessingJobsForUpdate(int limit)` default 메서드 추가 — 기존 `findPendingJobsForUpdate(String status, int limit)` 네이티브 쿼리를 `PROCESSING` 상태로 재사용

JobPollProcessor

- `fetchProcessingJobs(int limit)` — `@Transactional`, `SELECT ... FOR UPDATE SKIP LOCKED`로 PROCESSING 잡 조회
- `pollOne(Long id)` — `@Transactional(REQUIRES_NEW)`, 잡별 독립 트랜잭션으로 한 건 실패가 다른 건에 영향을 주지 않도록 격리
  - `findById`로 재조회(새 트랜잭션 영속성 컨텍스트)
  - PROCESSING 아닌 잡 스킵(경합 방어)
  - `MockWorkerClient.getJobStatus(workerJobId)` 호출
    - `COMPLETED` → `markCompleted(result)`
    - `FAILED` → `markFailed(errorMessage)`
    - `PROCESSING` → no-op (다음 주기에 재확인)
  - `MockWorkerException` → `log.warn`만 기록, 잡 상태 유지 (다음 주기에 재시도) — Dispatcher와의 핵심 차이

JobPoller

- `@Scheduled(fixedDelay = 5000)` — 5초 주기, 이전 실행 완료 후 측정
- `@Value("${polling.batch-size:10}")` — 배치 사이즈 외부 설정
- 잡별 `try-catch`로 루프 중단 방지

## 테스트

JobPollProcessorTest (단위 테스트, Mockito)

- Worker `COMPLETED` 응답 시 COMPLETED 전이 및 `result` 설정
- Worker `FAILED` 응답 시 FAILED 전이 및 `errorMessage` 설정
- Worker `PROCESSING` 응답 시 상태 변경 없음
- `MockWorkerException` 발생 시 상태 PROCESSING 유지 (markFailed 호출 안 함)
- 잡 미존재 시 `JOB_NOT_FOUND` 예외
- 이미 COMPLETED/FAILED 상태인 잡 스킵(경합 방어)

JobPollerTest (단위 테스트, Mockito)

- PROCESSING 잡이 있으면 각각 `pollOne` 호출
- PROCESSING 잡이 없으면 `pollOne` 미호출
- `pollOne` 예외 발생 시 다음 잡 계속 처리(장애 격리)