### PR TITLE
Feature/#8 JobRecoveryService 구현 - 서버 재시작 복구

### DIFF
--- a/src/main/java/com/realteeth/assignment/domain/entity/Job.java
+++ b/src/main/java/com/realteeth/assignment/domain/entity/Job.java
@@ -82,6 +82,7 @@ public class Job {
         this.errorMessage = errorMessage;
     }
 
+    // 서버 재시작 복구 전용 — 정상 전이 규칙(transitionTo)을 의도적으로 우회
     public void resetToPending() {
         if (this.status != JobStatus.PROCESSING) {
             throw new JobException(ErrorCode.INVALID_STATE_TRANSITION);

--- a/src/main/java/com/realteeth/assignment/domain/entity/Job.java
+++ b/src/main/java/com/realteeth/assignment/domain/entity/Job.java
@@ -1,6 +1,8 @@
 package com.realteeth.assignment.domain.entity;
 
 import com.realteeth.assignment.domain.enums.JobStatus;
+import com.realteeth.assignment.exception.ErrorCode;
+import com.realteeth.assignment.exception.JobException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -78,5 +80,13 @@ public class Job {
     public void markFailed(String errorMessage) {
         this.status = this.status.transitionTo(JobStatus.FAILED);
         this.errorMessage = errorMessage;
+    }
+
+    public void resetToPending() {
+        if (this.status != JobStatus.PROCESSING) {
+            throw new JobException(ErrorCode.INVALID_STATE_TRANSITION);
+        }
+        this.status = JobStatus.PENDING;
+        this.workerJobId = null;
     }
 }

--- a/src/main/java/com/realteeth/assignment/service/JobRecoveryService.java
+++ b/src/main/java/com/realteeth/assignment/service/JobRecoveryService.java
@@ -1,0 +1,37 @@
+package com.realteeth.assignment.service;
+
+import com.realteeth.assignment.domain.entity.Job;
+import com.realteeth.assignment.domain.enums.JobStatus;
+import com.realteeth.assignment.domain.repository.JobRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class JobRecoveryService {
+
+    private final JobRepository jobRepository;
+
+    @EventListener(ApplicationReadyEvent.class)
+    @Order(2)
+    @Transactional
+    public void recover() {
+        List<Job> processingJobs = jobRepository.findByStatus(JobStatus.PROCESSING);
+
+        for (Job job : processingJobs) {
+            job.resetToPending();
+        }
+
+        if (!processingJobs.isEmpty()) {
+            log.info("서버 재시작 복구: PROCESSING 잡 {}건을 PENDING으로 리셋", processingJobs.size());
+        }
+    }
+}

--- a/src/main/java/com/realteeth/assignment/service/JobRecoveryService.java
+++ b/src/main/java/com/realteeth/assignment/service/JobRecoveryService.java
@@ -31,7 +31,10 @@ public class JobRecoveryService {
         }
 
         if (!processingJobs.isEmpty()) {
-            log.info("서버 재시작 복구: PROCESSING 잡 {}건을 PENDING으로 리셋", processingJobs.size());
+            List<String> jobIds = processingJobs.stream()
+                    .map(job -> job.getJobId().toString())
+                    .toList();
+            log.info("서버 재시작 복구: PROCESSING 잡 {}건을 PENDING으로 리셋 {}", processingJobs.size(), jobIds);
         }
     }
 }

--- a/src/main/java/com/realteeth/assignment/worker/ApiKeyProvider.java
+++ b/src/main/java/com/realteeth/assignment/worker/ApiKeyProvider.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
@@ -19,6 +20,7 @@ public class ApiKeyProvider {
     private volatile String apiKey;
 
     @EventListener(ApplicationReadyEvent.class)
+    @Order(1)
     public void issueApiKey() {
         WebClient client = webClientBuilder
                 .baseUrl(properties.getBaseUrl())

--- a/src/test/java/com/realteeth/assignment/domain/JobTest.java
+++ b/src/test/java/com/realteeth/assignment/domain/JobTest.java
@@ -100,4 +100,43 @@ class JobTest {
         assertThatThrownBy(() -> job.markProcessing("worker-job-002"))
                 .isInstanceOf(JobException.class);
     }
+
+    @Test
+    void resetToPending은_PROCESSING_상태에서_PENDING으로_전이하고_workerJobId를_초기화한다() {
+        Job job = Job.create("https://example.com/image.jpg", "abc123hash");
+        job.markProcessing("worker-job-001");
+
+        job.resetToPending();
+
+        assertThat(job.getStatus()).isEqualTo(JobStatus.PENDING);
+        assertThat(job.getWorkerJobId()).isNull();
+    }
+
+    @Test
+    void resetToPending은_PENDING_상태에서_호출_시_예외가_발생한다() {
+        Job job = Job.create("https://example.com/image.jpg", "abc123hash");
+
+        assertThatThrownBy(job::resetToPending)
+                .isInstanceOf(JobException.class);
+    }
+
+    @Test
+    void resetToPending은_COMPLETED_상태에서_호출_시_예외가_발생한다() {
+        Job job = Job.create("https://example.com/image.jpg", "abc123hash");
+        job.markProcessing("worker-job-001");
+        job.markCompleted("result");
+
+        assertThatThrownBy(job::resetToPending)
+                .isInstanceOf(JobException.class);
+    }
+
+    @Test
+    void resetToPending은_FAILED_상태에서_호출_시_예외가_발생한다() {
+        Job job = Job.create("https://example.com/image.jpg", "abc123hash");
+        job.markProcessing("worker-job-001");
+        job.markFailed("error");
+
+        assertThatThrownBy(job::resetToPending)
+                .isInstanceOf(JobException.class);
+    }
 }

--- a/src/test/java/com/realteeth/assignment/service/JobRecoveryServiceTest.java
+++ b/src/test/java/com/realteeth/assignment/service/JobRecoveryServiceTest.java
@@ -1,0 +1,65 @@
+package com.realteeth.assignment.service;
+
+import com.realteeth.assignment.domain.entity.Job;
+import com.realteeth.assignment.domain.enums.JobStatus;
+import com.realteeth.assignment.domain.repository.JobRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class JobRecoveryServiceTest {
+
+    @Mock
+    private JobRepository jobRepository;
+
+    @InjectMocks
+    private JobRecoveryService jobRecoveryService;
+
+    private Job createProcessingJobWithId(Long id) {
+        Job job = Job.create("https://example.com/image.jpg", "hash-" + id);
+        ReflectionTestUtils.setField(job, "id", id);
+        job.markProcessing("worker-" + id);
+        return job;
+    }
+
+    @Test
+    void PROCESSING_잡이_여러_건_있으면_모두_PENDING으로_복구한다() {
+        Job job1 = createProcessingJobWithId(1L);
+        Job job2 = createProcessingJobWithId(2L);
+        given(jobRepository.findByStatus(JobStatus.PROCESSING)).willReturn(List.of(job1, job2));
+
+        jobRecoveryService.recover();
+
+        assertThat(job1.getStatus()).isEqualTo(JobStatus.PENDING);
+        assertThat(job1.getWorkerJobId()).isNull();
+        assertThat(job2.getStatus()).isEqualTo(JobStatus.PENDING);
+        assertThat(job2.getWorkerJobId()).isNull();
+    }
+
+    @Test
+    void PROCESSING_잡이_없으면_예외_없이_정상_완료한다() {
+        given(jobRepository.findByStatus(JobStatus.PROCESSING)).willReturn(List.of());
+
+        jobRecoveryService.recover();
+    }
+
+    @Test
+    void PROCESSING_잡이_1건_있으면_정상_복구한다() {
+        Job job = createProcessingJobWithId(1L);
+        given(jobRepository.findByStatus(JobStatus.PROCESSING)).willReturn(List.of(job));
+
+        jobRecoveryService.recover();
+
+        assertThat(job.getStatus()).isEqualTo(JobStatus.PENDING);
+        assertThat(job.getWorkerJobId()).isNull();
+    }
+}


### PR DESCRIPTION
## 관련 이슈
closes #8

## 작업 내용

Job

- `resetToPending()` — 복구 전용 상태 전이 메서드 추가. `JobStatus` enum의 정상 비즈니스 플로우 전이 규칙을 우회하지 않도록 별도 메서드로 분리. PROCESSING 상태 검증 후 `status=PENDING`, `workerJobId=null`로 초기화

ApiKeyProvider

- `@Order(1)` 추가 — `ApplicationReadyEvent` 리스너 실행 순서를 명시적으로 보장 (API Key 발급 → 복구 순서)

JobRecoveryService

- `@EventListener(ApplicationReadyEvent.class)` + `@Order(2)` — 앱 준비 완료 후 1회 실행
- `findByStatus(PROCESSING)` 으로 전체 PROCESSING 잡 조회 (시작 시점에 다른 스케줄러 미동작, `FOR UPDATE` 불필요)
- 각 잡에 `resetToPending()` 호출 — JPA dirty checking으로 별도 `save()` 없이 트랜잭션 커밋 시 일괄 flush
- 복구된 잡이 있을 때만 로그 출력

## 테스트

JobTest (단위 테스트)

- PROCESSING → PENDING 정상 전이 및 `workerJobId` null 초기화
- PENDING / COMPLETED / FAILED 상태에서 `resetToPending()` 호출 시 `JobException` 발생

JobRecoveryServiceTest (단위 테스트, Mockito)

- PROCESSING 잡 여러 건 존재 시 모두 PENDING 복구 및 `workerJobId` null 확인
- PROCESSING 잡 없을 때 예외 없이 정상 완료
- PROCESSING 잡 1건 존재 시 정상 복구