### PR TITLE
Feature/#24 API Key 기동 실패 방지 및 만료 시 재발급 처리

### DIFF
--- a/src/main/java/com/realteeth/assignment/worker/ApiKeyProvider.java
+++ b/src/main/java/com/realteeth/assignment/worker/ApiKeyProvider.java
@@ -1,6 +1,8 @@
 package com.realteeth.assignment.worker;
 
 import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
@@ -18,10 +20,45 @@ public class ApiKeyProvider {
     private final MockWorkerProperties properties;
     private final WebClient.Builder webClientBuilder;
     private volatile String apiKey;
+    private final ReentrantLock refreshLock = new ReentrantLock();
 
     @EventListener(ApplicationReadyEvent.class)
     @Order(1)
     public void issueApiKey() {
+        try {
+            refreshInternal();
+            log.info("Mock Worker API Key 발급 완료");
+        } catch (Exception e) {
+            log.warn("Mock Worker API Key 발급 실패 — 서버는 정상 기동, 첫 API 호출 시 재시도: {}", e.getMessage());
+        }
+    }
+
+    public boolean refresh() {
+        try {
+            if (!refreshLock.tryLock(15, TimeUnit.SECONDS)) {
+                return apiKey != null;
+            }
+            try {
+                refreshInternal();
+                log.info("Mock Worker API Key 재발급 완료");
+                return true;
+            } catch (Exception e) {
+                log.warn("Mock Worker API Key 재발급 실패: {}", e.getMessage());
+                return false;
+            } finally {
+                refreshLock.unlock();
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
+        }
+    }
+
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    private void refreshInternal() {
         WebClient client = webClientBuilder
                 .baseUrl(properties.getBaseUrl())
                 .build();
@@ -39,11 +76,6 @@ public class ApiKeyProvider {
         }
 
         this.apiKey = response.apiKey();
-        log.info("Mock Worker API Key 발급 완료");
-    }
-
-    public String getApiKey() {
-        return apiKey;
     }
 
     private record IssueKeyRequest(String candidateName, String email) {}

--- a/src/main/java/com/realteeth/assignment/worker/ApiKeyProvider.java
+++ b/src/main/java/com/realteeth/assignment/worker/ApiKeyProvider.java
@@ -29,7 +29,7 @@ public class ApiKeyProvider {
             refreshInternal();
             log.info("Mock Worker API Key 발급 완료");
         } catch (Exception e) {
-            log.warn("Mock Worker API Key 발급 실패 — 서버는 정상 기동, 첫 API 호출 시 재시도: {}", e.getMessage());
+            log.warn("Mock Worker API Key 발급 실패 — 서버는 정상 기동, 첫 API 호출 시 재시도", e);
         }
     }
 
@@ -46,7 +46,7 @@ public class ApiKeyProvider {
                 log.info("Mock Worker API Key 재발급 완료");
                 return true;
             } catch (Exception e) {
-                log.warn("Mock Worker API Key 재발급 실패: {}", e.getMessage());
+                log.warn("Mock Worker API Key 재발급 실패", e);
                 return false;
             } finally {
                 refreshLock.unlock();

--- a/src/main/java/com/realteeth/assignment/worker/ApiKeyProvider.java
+++ b/src/main/java/com/realteeth/assignment/worker/ApiKeyProvider.java
@@ -33,12 +33,15 @@ public class ApiKeyProvider {
         }
     }
 
-    public boolean refresh() {
+    public boolean refresh(String expiredKey) {
         try {
             if (!refreshLock.tryLock(15, TimeUnit.SECONDS)) {
                 return apiKey != null;
             }
             try {
+                if (expiredKey != null && !expiredKey.equals(this.apiKey)) {
+                    return true;
+                }
                 refreshInternal();
                 log.info("Mock Worker API Key 재발급 완료");
                 return true;

--- a/src/main/java/com/realteeth/assignment/worker/MockWorkerClient.java
+++ b/src/main/java/com/realteeth/assignment/worker/MockWorkerClient.java
@@ -56,8 +56,15 @@ public class MockWorkerClient {
     }
 
     private static class ApiKeyExpiredException extends RuntimeException {
-        ApiKeyExpiredException() {
+        private final String expiredKey;
+
+        ApiKeyExpiredException(String expiredKey) {
             super("API Key 만료 (401)");
+            this.expiredKey = expiredKey;
+        }
+
+        String getExpiredKey() {
+            return expiredKey;
         }
     }
 
@@ -66,7 +73,7 @@ public class MockWorkerClient {
         try {
             return doSubmitJob(imageUrl);
         } catch (ApiKeyExpiredException e) {
-            if (apiKeyProvider.refresh()) {
+            if (apiKeyProvider.refresh(e.getExpiredKey())) {
                 return doSubmitJob(imageUrl);
             }
             throw new MockWorkerException(ErrorCode.MOCK_WORKER_ERROR);
@@ -116,7 +123,11 @@ public class MockWorkerClient {
     }
 
     private ProcessStartResponse doSubmitJob(String imageUrl) {
-        return authenticatedClient()
+        String currentKey = resolveApiKey();
+        return webClient.mutate()
+                .baseUrl(properties.getBaseUrl())
+                .defaultHeader("X-API-KEY", currentKey)
+                .build()
                 .post()
                 .uri("/process")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -124,7 +135,7 @@ public class MockWorkerClient {
                 .retrieve()
                 .onStatus(HttpStatusCode::is4xxClientError, response -> {
                     if (response.statusCode().value() == 401) {
-                        return Mono.error(new ApiKeyExpiredException());
+                        return Mono.error(new ApiKeyExpiredException(currentKey));
                     }
                     if (response.statusCode().value() == 429) {
                         return Mono.error(new RetryableException("429 Too Many Requests", null));
@@ -145,11 +156,10 @@ public class MockWorkerClient {
                 .block(Duration.ofSeconds(65));
     }
 
-    // POST /mock/process — X-API-KEY 인증 필요
-    private WebClient authenticatedClient() {
+    private String resolveApiKey() {
         String key = apiKeyProvider.getApiKey();
         if (key == null) {
-            if (!apiKeyProvider.refresh()) {
+            if (!apiKeyProvider.refresh(null)) {
                 throw new MockWorkerException(ErrorCode.MOCK_WORKER_ERROR);
             }
             key = apiKeyProvider.getApiKey();
@@ -157,10 +167,7 @@ public class MockWorkerClient {
                 throw new MockWorkerException(ErrorCode.MOCK_WORKER_ERROR);
             }
         }
-        return webClient.mutate()
-                .baseUrl(properties.getBaseUrl())
-                .defaultHeader("X-API-KEY", key)
-                .build();
+        return key;
     }
 
     // GET /mock/process/{id} — 인증 불필요

--- a/src/main/java/com/realteeth/assignment/worker/MockWorkerClient.java
+++ b/src/main/java/com/realteeth/assignment/worker/MockWorkerClient.java
@@ -55,32 +55,22 @@ public class MockWorkerClient {
         }
     }
 
+    private static class ApiKeyExpiredException extends RuntimeException {
+        ApiKeyExpiredException() {
+            super("API Key 만료 (401)");
+        }
+    }
+
     @CircuitBreaker(name = CIRCUIT_BREAKER_NAME, fallbackMethod = "submitJobFallback")
     public ProcessStartResponse submitJob(String imageUrl) {
-        return client()
-                .post()
-                .uri("/process")
-                .contentType(MediaType.APPLICATION_JSON)
-                .bodyValue(new SubmitRequest(imageUrl))
-                .retrieve()
-                .onStatus(HttpStatusCode::is4xxClientError, response -> {
-                    if (response.statusCode().value() == 429) {
-                        return Mono.error(new RetryableException("429 Too Many Requests", null));
-                    }
-                    return Mono.error(new MockWorkerException(ErrorCode.MOCK_WORKER_ERROR));
-                })
-                .onStatus(HttpStatusCode::is5xxServerError, response ->
-                        Mono.error(new RetryableException("5xx Server Error", null))
-                )
-                .bodyToMono(ProcessStartResponse.class)
-                .switchIfEmpty(Mono.error(new MockWorkerException(ErrorCode.MOCK_WORKER_ERROR)))
-                .onErrorMap(WebClientRequestException.class, e -> new RetryableException("네트워크 오류", e))
-                .retryWhen(Retry.fixedDelay(MAX_RETRY_ATTEMPTS, Duration.ofMillis(500))
-                        .filter(e -> e instanceof RetryableException))
-                .onErrorMap(RetryableException.class, e -> new MockWorkerException(ErrorCode.MOCK_WORKER_ERROR, e))
-                .onErrorMap(e -> !(e instanceof MockWorkerException),
-                        e -> new MockWorkerException(ErrorCode.MOCK_WORKER_ERROR, e))
-                .block(Duration.ofSeconds(65));
+        try {
+            return doSubmitJob(imageUrl);
+        } catch (ApiKeyExpiredException e) {
+            if (apiKeyProvider.refresh()) {
+                return doSubmitJob(imageUrl);
+            }
+            throw new MockWorkerException(ErrorCode.MOCK_WORKER_ERROR);
+        }
     }
 
     @CircuitBreaker(name = CIRCUIT_BREAKER_NAME, fallbackMethod = "getJobStatusFallback")
@@ -125,10 +115,58 @@ public class MockWorkerClient {
         throw new MockWorkerException(ErrorCode.MOCK_WORKER_ERROR, t);
     }
 
+    private ProcessStartResponse doSubmitJob(String imageUrl) {
+        return authenticatedClient()
+                .post()
+                .uri("/process")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(new SubmitRequest(imageUrl))
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, response -> {
+                    if (response.statusCode().value() == 401) {
+                        return Mono.error(new ApiKeyExpiredException());
+                    }
+                    if (response.statusCode().value() == 429) {
+                        return Mono.error(new RetryableException("429 Too Many Requests", null));
+                    }
+                    return Mono.error(new MockWorkerException(ErrorCode.MOCK_WORKER_ERROR));
+                })
+                .onStatus(HttpStatusCode::is5xxServerError, response ->
+                        Mono.error(new RetryableException("5xx Server Error", null))
+                )
+                .bodyToMono(ProcessStartResponse.class)
+                .switchIfEmpty(Mono.error(new MockWorkerException(ErrorCode.MOCK_WORKER_ERROR)))
+                .onErrorMap(WebClientRequestException.class, e -> new RetryableException("네트워크 오류", e))
+                .retryWhen(Retry.fixedDelay(MAX_RETRY_ATTEMPTS, Duration.ofMillis(500))
+                        .filter(e -> e instanceof RetryableException))
+                .onErrorMap(RetryableException.class, e -> new MockWorkerException(ErrorCode.MOCK_WORKER_ERROR, e))
+                .onErrorMap(e -> !(e instanceof MockWorkerException) && !(e instanceof ApiKeyExpiredException),
+                        e -> new MockWorkerException(ErrorCode.MOCK_WORKER_ERROR, e))
+                .block(Duration.ofSeconds(65));
+    }
+
+    // POST /mock/process — X-API-KEY 인증 필요
+    private WebClient authenticatedClient() {
+        String key = apiKeyProvider.getApiKey();
+        if (key == null) {
+            if (!apiKeyProvider.refresh()) {
+                throw new MockWorkerException(ErrorCode.MOCK_WORKER_ERROR);
+            }
+            key = apiKeyProvider.getApiKey();
+            if (key == null) {
+                throw new MockWorkerException(ErrorCode.MOCK_WORKER_ERROR);
+            }
+        }
+        return webClient.mutate()
+                .baseUrl(properties.getBaseUrl())
+                .defaultHeader("X-API-KEY", key)
+                .build();
+    }
+
+    // GET /mock/process/{id} — 인증 불필요
     private WebClient client() {
         return webClient.mutate()
                 .baseUrl(properties.getBaseUrl())
-                .defaultHeader("X-API-KEY", apiKeyProvider.getApiKey())
                 .build();
     }
 }

--- a/src/main/java/com/realteeth/assignment/worker/MockWorkerClient.java
+++ b/src/main/java/com/realteeth/assignment/worker/MockWorkerClient.java
@@ -76,7 +76,7 @@ public class MockWorkerClient {
             if (apiKeyProvider.refresh(e.getExpiredKey())) {
                 return doSubmitJob(imageUrl);
             }
-            throw new MockWorkerException(ErrorCode.MOCK_WORKER_ERROR);
+            throw new MockWorkerException(ErrorCode.MOCK_WORKER_ERROR, e);
         }
     }
 
@@ -159,11 +159,14 @@ public class MockWorkerClient {
     private String resolveApiKey() {
         String key = apiKeyProvider.getApiKey();
         if (key == null) {
+            log.warn("API Key가 null — 재발급 시도");
             if (!apiKeyProvider.refresh(null)) {
+                log.warn("API Key 재발급 실패");
                 throw new MockWorkerException(ErrorCode.MOCK_WORKER_ERROR);
             }
             key = apiKeyProvider.getApiKey();
             if (key == null) {
+                log.warn("재발급 후에도 API Key가 null");
                 throw new MockWorkerException(ErrorCode.MOCK_WORKER_ERROR);
             }
         }

--- a/src/test/java/com/realteeth/assignment/worker/ApiKeyProviderTest.java
+++ b/src/test/java/com/realteeth/assignment/worker/ApiKeyProviderTest.java
@@ -11,7 +11,6 @@ import org.springframework.web.reactive.function.client.WebClient;
 import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ApiKeyProviderTest {
 
@@ -53,41 +52,45 @@ class ApiKeyProviderTest {
     }
 
     @Test
-    void apiKey가_null인_응답시_예외가_발생한다() {
+    void apiKey가_null인_응답시_apiKey가_null로_유지된다() {
         server.enqueue(new MockResponse()
                 .setBody("{\"apiKey\":null}")
                 .addHeader("Content-Type", "application/json"));
 
-        assertThatThrownBy(() -> apiKeyProvider.issueApiKey())
-                .isInstanceOf(IllegalStateException.class);
+        apiKeyProvider.issueApiKey();
+
+        assertThat(apiKeyProvider.getApiKey()).isNull();
     }
 
     @Test
-    void apiKey가_빈_문자열인_응답시_예외가_발생한다() {
+    void apiKey가_빈_문자열인_응답시_apiKey가_null로_유지된다() {
         server.enqueue(new MockResponse()
                 .setBody("{\"apiKey\":\"\"}")
                 .addHeader("Content-Type", "application/json"));
 
-        assertThatThrownBy(() -> apiKeyProvider.issueApiKey())
-                .isInstanceOf(IllegalStateException.class);
+        apiKeyProvider.issueApiKey();
+
+        assertThat(apiKeyProvider.getApiKey()).isNull();
     }
 
     @Test
-    void apiKey가_공백만_있는_응답시_예외가_발생한다() {
+    void apiKey가_공백만_있는_응답시_apiKey가_null로_유지된다() {
         server.enqueue(new MockResponse()
                 .setBody("{\"apiKey\":\"   \"}")
                 .addHeader("Content-Type", "application/json"));
 
-        assertThatThrownBy(() -> apiKeyProvider.issueApiKey())
-                .isInstanceOf(IllegalStateException.class);
+        apiKeyProvider.issueApiKey();
+
+        assertThat(apiKeyProvider.getApiKey()).isNull();
     }
 
     @Test
-    void 서버_오류시_예외가_발생한다() {
+    void 서버_오류시_apiKey가_null로_유지된다() {
         server.enqueue(new MockResponse().setResponseCode(500));
 
-        assertThatThrownBy(() -> apiKeyProvider.issueApiKey())
-                .isInstanceOf(Exception.class);
+        apiKeyProvider.issueApiKey();
+
+        assertThat(apiKeyProvider.getApiKey()).isNull();
     }
 
     @Test
@@ -102,5 +105,46 @@ class ApiKeyProviderTest {
         String body = request.getBody().readUtf8();
         assertThat(body).contains("tester");
         assertThat(body).contains("tester@test.com");
+    }
+
+    @Test
+    void refresh_정상_응답시_apiKey를_갱신하고_true를_반환한다() {
+        server.enqueue(new MockResponse()
+                .setBody("{\"apiKey\":\"new-key-123\"}")
+                .addHeader("Content-Type", "application/json"));
+
+        boolean result = apiKeyProvider.refresh();
+
+        assertThat(result).isTrue();
+        assertThat(apiKeyProvider.getApiKey()).isEqualTo("new-key-123");
+    }
+
+    @Test
+    void refresh_서버_오류시_false를_반환하고_기존_키를_유지한다() {
+        server.enqueue(new MockResponse()
+                .setBody("{\"apiKey\":\"old-key\"}")
+                .addHeader("Content-Type", "application/json"));
+        apiKeyProvider.issueApiKey();
+
+        server.enqueue(new MockResponse().setResponseCode(500));
+
+        boolean result = apiKeyProvider.refresh();
+
+        assertThat(result).isFalse();
+        assertThat(apiKeyProvider.getApiKey()).isEqualTo("old-key");
+    }
+
+    @Test
+    void refresh_성공시_기존_null_apiKey가_갱신된다() {
+        assertThat(apiKeyProvider.getApiKey()).isNull();
+
+        server.enqueue(new MockResponse()
+                .setBody("{\"apiKey\":\"recovered-key\"}")
+                .addHeader("Content-Type", "application/json"));
+
+        boolean result = apiKeyProvider.refresh();
+
+        assertThat(result).isTrue();
+        assertThat(apiKeyProvider.getApiKey()).isEqualTo("recovered-key");
     }
 }

--- a/src/test/java/com/realteeth/assignment/worker/ApiKeyProviderTest.java
+++ b/src/test/java/com/realteeth/assignment/worker/ApiKeyProviderTest.java
@@ -113,7 +113,7 @@ class ApiKeyProviderTest {
                 .setBody("{\"apiKey\":\"new-key-123\"}")
                 .addHeader("Content-Type", "application/json"));
 
-        boolean result = apiKeyProvider.refresh();
+        boolean result = apiKeyProvider.refresh(null);
 
         assertThat(result).isTrue();
         assertThat(apiKeyProvider.getApiKey()).isEqualTo("new-key-123");
@@ -128,7 +128,7 @@ class ApiKeyProviderTest {
 
         server.enqueue(new MockResponse().setResponseCode(500));
 
-        boolean result = apiKeyProvider.refresh();
+        boolean result = apiKeyProvider.refresh("old-key");
 
         assertThat(result).isFalse();
         assertThat(apiKeyProvider.getApiKey()).isEqualTo("old-key");
@@ -142,9 +142,24 @@ class ApiKeyProviderTest {
                 .setBody("{\"apiKey\":\"recovered-key\"}")
                 .addHeader("Content-Type", "application/json"));
 
-        boolean result = apiKeyProvider.refresh();
+        boolean result = apiKeyProvider.refresh(null);
 
         assertThat(result).isTrue();
         assertThat(apiKeyProvider.getApiKey()).isEqualTo("recovered-key");
+    }
+
+    @Test
+    void refresh_이미_다른_스레드가_갱신했으면_재발급_없이_true를_반환한다() {
+        server.enqueue(new MockResponse()
+                .setBody("{\"apiKey\":\"current-key\"}")
+                .addHeader("Content-Type", "application/json"));
+        apiKeyProvider.issueApiKey();
+
+        // expiredKey가 현재 키와 다르면 이미 갱신된 것으로 판단 → 서버 호출 없이 true 반환
+        boolean result = apiKeyProvider.refresh("old-expired-key");
+
+        assertThat(result).isTrue();
+        assertThat(apiKeyProvider.getApiKey()).isEqualTo("current-key");
+        assertThat(server.getRequestCount()).isEqualTo(1); // issueApiKey 1회만
     }
 }

--- a/src/test/java/com/realteeth/assignment/worker/MockWorkerClientTest.java
+++ b/src/test/java/com/realteeth/assignment/worker/MockWorkerClientTest.java
@@ -20,6 +20,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @SpringBootTest(
@@ -237,6 +238,63 @@ class MockWorkerClientTest {
 
         assertThat(response.status()).isEqualTo("COMPLETED");
         assertThat(response.result()).isNull();
+    }
+
+    // ==================== 401 재발급 재시도 ====================
+
+    @Test
+    void submitJob_401_후_재발급_성공시_재시도하여_성공한다() throws InterruptedException {
+        server.enqueue(new MockResponse().setResponseCode(401));
+        server.enqueue(new MockResponse()
+                .setBody("{\"jobId\":\"worker-010\",\"status\":\"PROCESSING\"}")
+                .addHeader("Content-Type", "application/json"));
+
+        when(apiKeyProvider.refresh()).thenReturn(true);
+        when(apiKeyProvider.getApiKey()).thenReturn("test-api-key", "new-api-key");
+
+        MockWorkerClient.ProcessStartResponse response = mockWorkerClient.submitJob("https://example.com/img.jpg");
+
+        assertThat(response.jobId()).isEqualTo("worker-010");
+        assertThat(server.getRequestCount()).isEqualTo(2);
+        verify(apiKeyProvider).refresh();
+    }
+
+    @Test
+    void submitJob_401_후_재발급_실패시_MockWorkerException이_발생한다() {
+        server.enqueue(new MockResponse().setResponseCode(401));
+
+        when(apiKeyProvider.refresh()).thenReturn(false);
+
+        assertThatThrownBy(() -> mockWorkerClient.submitJob("https://example.com/img.jpg"))
+                .isInstanceOf(MockWorkerException.class);
+
+        verify(apiKeyProvider).refresh();
+    }
+
+    @Test
+    void submitJob_apiKey가_null이면_refresh_시도_후_정상_동작한다() {
+        server.enqueue(new MockResponse()
+                .setBody("{\"jobId\":\"worker-011\",\"status\":\"PROCESSING\"}")
+                .addHeader("Content-Type", "application/json"));
+
+        when(apiKeyProvider.getApiKey()).thenReturn(null, "recovered-key");
+        when(apiKeyProvider.refresh()).thenReturn(true);
+
+        MockWorkerClient.ProcessStartResponse response = mockWorkerClient.submitJob("https://example.com/img.jpg");
+
+        assertThat(response.jobId()).isEqualTo("worker-011");
+        verify(apiKeyProvider).refresh();
+    }
+
+    @Test
+    void submitJob_apiKey가_null이고_refresh도_실패하면_MockWorkerException이_발생한다() {
+        when(apiKeyProvider.getApiKey()).thenReturn(null);
+        when(apiKeyProvider.refresh()).thenReturn(false);
+
+        assertThatThrownBy(() -> mockWorkerClient.submitJob("https://example.com/img.jpg"))
+                .isInstanceOf(MockWorkerException.class);
+
+        assertThat(server.getRequestCount()).isEqualTo(0);
     }
 
     // ==================== JSON 역직렬화 오류 ====================

--- a/src/test/java/com/realteeth/assignment/worker/MockWorkerClientTest.java
+++ b/src/test/java/com/realteeth/assignment/worker/MockWorkerClientTest.java
@@ -20,6 +20,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -249,26 +250,26 @@ class MockWorkerClientTest {
                 .setBody("{\"jobId\":\"worker-010\",\"status\":\"PROCESSING\"}")
                 .addHeader("Content-Type", "application/json"));
 
-        when(apiKeyProvider.refresh()).thenReturn(true);
+        when(apiKeyProvider.refresh(any())).thenReturn(true);
         when(apiKeyProvider.getApiKey()).thenReturn("test-api-key", "new-api-key");
 
         MockWorkerClient.ProcessStartResponse response = mockWorkerClient.submitJob("https://example.com/img.jpg");
 
         assertThat(response.jobId()).isEqualTo("worker-010");
         assertThat(server.getRequestCount()).isEqualTo(2);
-        verify(apiKeyProvider).refresh();
+        verify(apiKeyProvider).refresh(any());
     }
 
     @Test
     void submitJob_401_후_재발급_실패시_MockWorkerException이_발생한다() {
         server.enqueue(new MockResponse().setResponseCode(401));
 
-        when(apiKeyProvider.refresh()).thenReturn(false);
+        when(apiKeyProvider.refresh(any())).thenReturn(false);
 
         assertThatThrownBy(() -> mockWorkerClient.submitJob("https://example.com/img.jpg"))
                 .isInstanceOf(MockWorkerException.class);
 
-        verify(apiKeyProvider).refresh();
+        verify(apiKeyProvider).refresh(any());
     }
 
     @Test
@@ -278,18 +279,18 @@ class MockWorkerClientTest {
                 .addHeader("Content-Type", "application/json"));
 
         when(apiKeyProvider.getApiKey()).thenReturn(null, "recovered-key");
-        when(apiKeyProvider.refresh()).thenReturn(true);
+        when(apiKeyProvider.refresh(any())).thenReturn(true);
 
         MockWorkerClient.ProcessStartResponse response = mockWorkerClient.submitJob("https://example.com/img.jpg");
 
         assertThat(response.jobId()).isEqualTo("worker-011");
-        verify(apiKeyProvider).refresh();
+        verify(apiKeyProvider).refresh(any());
     }
 
     @Test
     void submitJob_apiKey가_null이고_refresh도_실패하면_MockWorkerException이_발생한다() {
         when(apiKeyProvider.getApiKey()).thenReturn(null);
-        when(apiKeyProvider.refresh()).thenReturn(false);
+        when(apiKeyProvider.refresh(any())).thenReturn(false);
 
         assertThatThrownBy(() -> mockWorkerClient.submitJob("https://example.com/img.jpg"))
                 .isInstanceOf(MockWorkerException.class);


### PR DESCRIPTION
## 관련 이슈
closes #24

## 작업 내용

ApiKeyProvider

- `issueApiKey()` — 발급 실패 시 예외 대신 경고 로그 + `apiKey = null` 유지. 외부 서비스 일시 장애로 서버가 종료되지 않도록 수정
- `refreshInternal()` — 기존 발급 로직을 내부 메서드로 추출
- `refresh()` — 외부에서 재발급 트리거 가능한 public 메서드 추가. `ReentrantLock.tryLock(15초)`으로 동시 재발급 요청 방지. 성공 시 `true`, 실패 시 `false` 반환

MockWorkerClient

- `authenticatedClient()` / `client()` 분리 — Mock Worker OpenAPI 스펙 확인 결과 `POST /mock/process`만 `X-API-KEY` 인증 필요, `GET /mock/process/{id}`는 인증 불필요
- `ApiKeyExpiredException` — 401 응답 전용 내부 예외 클래스 추가
- `submitJob()` — 401 감지 시 `apiKeyProvider.refresh()` 호출 후 1회 재시도. 재발급 실패 시 `MockWorkerException(MOCK_WORKER_ERROR)` 반환
- `authenticatedClient()` — `apiKey`가 null인 상태에서 호출 시 `refresh()` 선행 시도. 재발급 후에도 null이면 즉시 실패
- `getJobStatus()` — 인증 불필요 API이므로 변경 없음

## 테스트

ApiKeyProviderTest

- 기존 4건 수정: `IllegalStateException` 검증 → `apiKey == null` 유지 검증으로 변경
- 신규 3건 추가: `refresh()` 성공/실패/null 키 복구 시나리오

MockWorkerClientTest

- 신규 4건 추가: 401 후 재발급 성공+재시도, 재발급 실패, apiKey null 상태에서 복구 성공/실패